### PR TITLE
Allow TemplateExpressions to pass the no-string-based-set-timeout rule

### DIFF
--- a/src/AstUtils.ts
+++ b/src/AstUtils.ts
@@ -76,9 +76,9 @@ module AstUtils {
             return true;
         }
 
-        if (expression.getFullText() === 'functionArg') {
-            //AstUtils.dumpTypeInfo(expression, this.languageServices, this.typeChecker);
-        }
+        //if (expression.getFullText() === 'functionArg') {
+        //    AstUtils.dumpTypeInfo(expression, this.languageServices, this.typeChecker);
+        //}
 
         return false; // by default the expression does not evaluate to a function
     }

--- a/src/AstUtils.ts
+++ b/src/AstUtils.ts
@@ -31,6 +31,9 @@ module AstUtils {
         if (expression.kind === ts.SyntaxKind.FunctionExpression) {
             return true; // function expressions are OK to pass
         }
+        if (expression.kind === ts.SyntaxKind.TemplateExpression) {
+            return true; // template expressions are OK to pass
+        }
         if (expression.kind === ts.SyntaxKind.Identifier) {
             let typeInfo : ts.DefinitionInfo[] = languageServices.getTypeDefinitionAtPosition('file.ts', expression.getStart());
             if (typeInfo != null && typeInfo[0] != null && typeInfo[0].kind === 'function') {


### PR DESCRIPTION
in my AngularJS app the `no-string-based-set-timeout` rule was bombing out on me with the following error

```
[13:12:22] [gulp-tslint] error layout/side-menu.directive.ts[125, 3]: An error occurred visiting a node.
Walker: NoStringParameterToFunctionCallWalker
Node: 
		$window.setTimeout(() => {
			// do stuff here
		}, 200)
TypeError: Cannot read property 'flags' of undefined
```
In Angular it's is discouraged to directly call `setTimeout` or anything on the `window` object since in a non-browser test environment you would not have a `window` object.  Instead an AngularJS version of it called `$window` is injected and normal `window` functions are called from this instead.

I'm not 100% certain that my proposed fixed will work in all cases, but it worked in mine.  I'm not totally sure what a `TemplateFunction` in TypeScript is anyway.