### PR TITLE
Set & declare var on same line

### DIFF
--- a/src/noStringBasedSetImmediateRule.ts
+++ b/src/noStringBasedSetImmediateRule.ts
@@ -7,9 +7,8 @@ import NoStringParameterToFunctionCallWalker = require('./utils/NoStringParamete
 export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile : ts.SourceFile): Lint.RuleFailure[] {
-        var languageServiceHost;
         var documentRegistry = ts.createDocumentRegistry();
-        languageServiceHost = Lint.createLanguageServiceHost('file.ts', sourceFile.getFullText());
+        var languageServiceHost = Lint.createLanguageServiceHost('file.ts', sourceFile.getFullText());
         var languageService = ts.createLanguageService(languageServiceHost, documentRegistry);
 
         var walker : Lint.RuleWalker = new NoStringParameterToFunctionCallWalker(


### PR DESCRIPTION
Useful for Visual Studio projects with the "Allow implicit `any` type" disabled.  Otherwise Visual Studio complains with the error:
`Error	TS7005	Variable 'languageServiceHost' implicitly has an 'any' type.`