### PR TITLE
Add npm badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![npm version](https://badge.fury.io/js/tslint-microsoft-contrib.svg)](https://badge.fury.io/js/tslint-microsoft-contrib)
 
 tslint-microsoft-contrib
 ======


### PR DESCRIPTION
Same badge as the TypeScript team has [here](https://github.com/Microsoft/TypeScript)

Feel free to close if this isn't something you want here though :)