### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - '4'
+  - '0.10'
+
+before_script:
+  - npm install -g grunt-cli
+
+sudo: false

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   ],
   "license": "MIT",
   "analyze": true,
+  "scripts": {
+    "test": "grunt all"
+  },
   "devDependencies": {
     "chai": "3.2.0",
     "grunt": "0.4.5",


### PR DESCRIPTION
You can see a sample run here: https://travis-ci.org/DickvdBrink/tslint-microsoft-contrib/jobs/86705510

I think for it to work on this repo it needs to be added to the Microsoft Travis account - TypeScript team also uses Travis so it should be possible :)

Feel free to close this one but I think it is pretty cool to have the tests run on every commit/pr ! :) 

