### PR TITLE
Allow the tests to check the optional rule parameters

### DIFF
--- a/tests/ChaiVagueErrorsRuleTests.ts
+++ b/tests/ChaiVagueErrorsRuleTests.ts
@@ -4,35 +4,35 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
  */
-describe('chaiVagueErrorsRule', () : void => {
+describe('chaiVagueErrorsRule', (): void => {
 
-    var ruleName : string = 'chai-vague-errors';
+    var ruleName: string = 'chai-vague-errors';
 
-    it('should pass on xxx', () : void => {
-        var script : string = `
+    it('should pass on xxx', (): void => {
+        var script: string = `
             expect(something).to.equal(true, 'message');;
             expect(something).to.be.equal(false, 'message');;
             expect(something).to.not.equal(null, 'message');;
             expect(something).to.not.be.equal(undefined, 'message');;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, []);
     });
 
-    it('should fail on ok', () : void => {
-        var script : string = `
+    it('should fail on ok', (): void => {
+        var script: string = `
             expect(something).to.ok;
             chai.expect(something).to.ok;
             expect(something).to.be.ok;
             chai.expect(something).to.not.be.ok;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -60,14 +60,14 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on true', () : void => {
-        var script : string = `
+    it('should fail on true', (): void => {
+        var script: string = `
             expect(something).to.true;
             chai.expect(something).to.be.true;
             expect(something).to.not.be.true;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -89,14 +89,14 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on false', () : void => {
-        var script : string = `
+    it('should fail on false', (): void => {
+        var script: string = `
             expect(something).to.false;
             expect(something).to.be.false;
             expect(something).to.not.be.false;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -118,14 +118,14 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on null', () : void => {
-        var script : string = `
+    it('should fail on null', (): void => {
+        var script: string = `
             expect(something).to.null;
             expect(something).to.be.null;
             expect(something).to.not.be.null;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -147,14 +147,14 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on undefined', () : void => {
-        var script : string = `
+    it('should fail on undefined', (): void => {
+        var script: string = `
             expect(something).to.undefined;
             expect(something).to.be.undefined;
             expect(something).to.not.be.undefined;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -176,8 +176,8 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on equal', () : void => {
-        var script : string = `
+    it('should fail on equal', (): void => {
+        var script: string = `
             expect(something).to.equal(true);
             expect(something).to.equals(true);
             expect(something).to.be.equal(true);
@@ -187,7 +187,7 @@ describe('chaiVagueErrorsRule', () : void => {
             expect(something).to.not.equal(undefined);
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",
@@ -233,8 +233,8 @@ describe('chaiVagueErrorsRule', () : void => {
         ]);
     });
 
-    it('should fail on eql', () : void => {
-        var script : string = `
+    it('should fail on eql', (): void => {
+        var script: string = `
             expect(something).to.eql(true);
             expect(something).to.be.eql(true);
             chai.expect(something).to.not.be.eql(false);
@@ -242,7 +242,7 @@ describe('chaiVagueErrorsRule', () : void => {
             chai.expect(something).to.not.eql(undefined);
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found chai call with vague failure message. Please add an explicit failure message",
                 "name": "file.ts",

--- a/tests/ExportNameRuleTests.ts
+++ b/tests/ExportNameRuleTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 import exportNameRule = require('../src/exportNameRule');
 
 /**
@@ -27,13 +27,13 @@ describe('exportNameRule', () : void => {
     it('should not produce violations for matching name', () : void => {
         exceptions.length = 0;
         var inputFile : string = 'test-data/ExportNameRulePassingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should produce violations for conflicting name', () : void => {
         exceptions.length = 0;
         var inputFile : string = 'test-data/ExportNameRuleFailingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "The exported module name must match the file name. " +
                     "Found: test-data/ExportNameRuleFailingTestInput.ts and ThisIsNotTheNameOfTheFile",
@@ -47,7 +47,7 @@ describe('exportNameRule', () : void => {
     it('should not produce violations for conflicting name when suppressed', () : void => {
         exceptions.push('ThisIsNot.*NameOfTheFile');
         var inputFile : string = 'test-data/ExportNameRuleFailingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [ ]);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [ ]);
     });
 
 });

--- a/tests/MissingJsdocRuleTests.ts
+++ b/tests/MissingJsdocRuleTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /* tslint:disable:no-octal-literal */
 /**
@@ -20,7 +20,7 @@ describe('missing-jsdoc', () : void => {
  */
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should not fail on top level comment with trailing spaces', () : void => {
@@ -30,14 +30,14 @@ function whatever() { }`;
  */
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on missing comment', () : void => {
         var script : string = `
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "File missing JSDoc comment at the top-level: file.ts",
                 "name": "file.ts",
@@ -54,7 +54,7 @@ function whatever() { }`;
  */
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "File missing JSDoc comment at the top-level: file.ts",
                 "name": "file.ts",
@@ -71,7 +71,7 @@ function whatever() { }`;
  */
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "File missing JSDoc comment at the top-level: file.ts",
                 "name": "file.ts",
@@ -88,7 +88,7 @@ function whatever() { }`;
  */
 function whatever() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "File missing JSDoc comment at the top-level: file.ts",
                 "name": "file.ts",
@@ -105,7 +105,7 @@ function whatever() { }`;
      */
     function indentedLikeAModuleFunction() { }`;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "File missing JSDoc comment at the top-level: file.ts",
                 "name": "file.ts",

--- a/tests/MissingOptionalAnnotationTests.ts
+++ b/tests/MissingOptionalAnnotationTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,17 +13,17 @@ describe('missingOptionalAnnotationRule', () : void => {
 
     it('should not produce violations', () : void => {
         var inputFile : string = 'test-data/MissingOptionalAnnotationPassingTestInput.ts';
-        TestHelper.assertViolations(ruleName, inputFile, []);
+        TestHelper.assertViolations(ruleName, null, inputFile, []);
     });
 
     it('should not produce violations for 2nd parameter that has a default initializer', () : void => {
         var script : string = 'function something(data? : any, others: Object = {}) { }';
-        TestHelper.assertViolations(ruleName, script, []);
+        TestHelper.assertViolations(ruleName, null, script, []);
     });
 
     it('should produce a violation when 1st parameter has a default initializer', () : void => {
         var script : string = 'function something(data : Object = {}, others: any) { }';
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Argument following optional argument missing optional annotation:  others: any",
                 "name": "file.ts",
@@ -38,9 +38,7 @@ describe('missingOptionalAnnotationRule', () : void => {
 
     it('should produce violations', () : void => {
         var inputFile : string = 'test-data/MissingOptionalAnnotationFailingTestInput.ts';
-        TestHelper.assertViolations(
-            ruleName,
-            inputFile,
+        TestHelper.assertViolations(ruleName, null, inputFile,
             [
                 {
                     "failure": "Argument following optional argument missing optional annotation:  requiredArg2",

--- a/tests/MochaAvoidOnlyRuleTests.ts
+++ b/tests/MochaAvoidOnlyRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -38,7 +38,7 @@ describe('mochaAvoidOnlyRule', () : void => {
             });
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on it.only with lambda', () : void => {
@@ -50,7 +50,7 @@ describe('mochaAvoidOnlyRule', () : void => {
             });
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not commit Mocha it.only function call",
                 "name": "file.ts",
@@ -69,7 +69,7 @@ describe('mochaAvoidOnlyRule', () : void => {
             });
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not commit Mocha it.only function call",
                 "name": "file.ts",
@@ -86,7 +86,7 @@ describe('mochaAvoidOnlyRule', () : void => {
             });
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not commit Mocha describe.only function call",
                 "name": "file.ts",
@@ -103,7 +103,7 @@ describe('mochaAvoidOnlyRule', () : void => {
             });
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not commit Mocha describe.only function call",
                 "name": "file.ts",

--- a/tests/NoBackboneGetSetOutsideModelRuleTests.ts
+++ b/tests/NoBackboneGetSetOutsideModelRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -19,7 +19,7 @@ describe('noBackboneGetSetOutsideModelRule', () : void => {
             this.set('modificationdate', datetime);
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should pass on get and set calls with wrong # parameters and wrong parameter types', () : void => {
@@ -33,7 +33,7 @@ describe('noBackboneGetSetOutsideModelRule', () : void => {
             model.set('modificationdate', value1, value2);
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on get and set on an object different than this', () : void => {
@@ -42,7 +42,7 @@ describe('noBackboneGetSetOutsideModelRule', () : void => {
             model.set('modificationdate', datetime);
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Backbone get() called outside of owning model: model.get('timestamp')",
                 "name": "file.ts",

--- a/tests/NoBannedTermsTests.ts
+++ b/tests/NoBannedTermsTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -16,7 +16,7 @@ describe('noBannedTermsRule', () : void => {
     describe('module variables', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var caller;
                 }`,
@@ -29,7 +29,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var callee;
                 }`,
@@ -42,7 +42,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var arguments;
                 }`,
@@ -55,7 +55,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var eval;
                 }`,
@@ -71,7 +71,7 @@ describe('noBannedTermsRule', () : void => {
     describe('module functions', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function caller() {}
                 }`,
@@ -84,7 +84,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function callee() {}
                 }`,
@@ -97,7 +97,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function arguments() {}
                 }`,
@@ -110,7 +110,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function eval() {}
                 }`,
@@ -126,7 +126,7 @@ describe('noBannedTermsRule', () : void => {
     describe('class variables', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private caller;
                 }`,
@@ -139,7 +139,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private callee;
                 }`,
@@ -152,7 +152,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private arguments;
                 }`,
@@ -165,7 +165,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private eval;
                 }`,
@@ -181,7 +181,7 @@ describe('noBannedTermsRule', () : void => {
     describe('class properties', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private var;
                     set caller(value) {}
@@ -202,7 +202,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private var;
                     set callee(value) {}
@@ -223,7 +223,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private var;
                     set arguments(value) {}
@@ -244,7 +244,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     private var;
                     set eval(value) {}
@@ -268,7 +268,7 @@ describe('noBannedTermsRule', () : void => {
     describe('class methods', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     caller() {}
                 }`,
@@ -281,7 +281,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     callee() {}
                 }`,
@@ -294,7 +294,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     arguments() {}
                 }`,
@@ -307,7 +307,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     eval() {}
                 }`,
@@ -323,7 +323,7 @@ describe('noBannedTermsRule', () : void => {
     describe('methods parameters', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     method(caller) {}
                 }`,
@@ -336,7 +336,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     method(callee) {}
                 }`,
@@ -349,7 +349,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     method(arguments) {}
                 }`,
@@ -362,7 +362,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `class Sample {
                     method(eval) {}
                 }`,
@@ -378,7 +378,7 @@ describe('noBannedTermsRule', () : void => {
     describe('function parameters', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function method(caller) {}
                 }`,
@@ -391,7 +391,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function method(callee) {}
                 }`,
@@ -404,7 +404,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function method(arguments) {}
                 }`,
@@ -417,7 +417,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     function method(eval) {}
                 }`,
@@ -433,7 +433,7 @@ describe('noBannedTermsRule', () : void => {
     describe('arrow function parameters', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var func = (caller) => {};
                 }`,
@@ -446,7 +446,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var func = (callee) => {};
                 }`,
@@ -459,7 +459,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var func = (arguments) => {};
                 }`,
@@ -472,7 +472,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `module Sample {
                     var func = (eval) => {};
                 }`,
@@ -488,7 +488,7 @@ describe('noBannedTermsRule', () : void => {
     describe('local variables', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `var caller;`,
                 [ {
                     "failure": "Forbidden reference to banned term: caller",
@@ -499,7 +499,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `var callee;`,
                 [{
                     "failure": "Forbidden reference to banned term: callee",
@@ -510,7 +510,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `var arguments`,
                 [ {
                     "failure": "Forbidden reference to banned term: arguments",
@@ -521,7 +521,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `var eval;`,
                 [  {
                     "failure": "Forbidden reference to banned term: eval",
@@ -535,7 +535,7 @@ describe('noBannedTermsRule', () : void => {
     describe('interface declarations', () => {
 
         it('should not refer to caller', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `interface Sample {
                     caller: any;
                 }`,
@@ -548,7 +548,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to callee', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `interface Sample {
                     callee: any;
                 }`,
@@ -561,7 +561,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to arguments', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `interface Sample {
                     arguments: any;
                 }`,
@@ -574,7 +574,7 @@ describe('noBannedTermsRule', () : void => {
         });
 
         it('should not refer to eval', () : void => {
-            TestHelper.assertViolations(RULE_NAME,
+            TestHelper.assertViolations(RULE_NAME,  null,
                 `interface Sample {
                     eval: any;
                 }`,

--- a/tests/NoConstantConditionRuleTests.ts
+++ b/tests/NoConstantConditionRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -21,7 +21,7 @@ describe('noConstantConditionRule', () : void => {
             if (1 > something) {}
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on if-booleans', () : void => {
@@ -30,7 +30,7 @@ describe('noConstantConditionRule', () : void => {
             if (true) {}
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: if (false)",
                 "name": "file.ts",
@@ -52,7 +52,7 @@ describe('noConstantConditionRule', () : void => {
             if (1) {}
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: if (0)",
                 "name": "file.ts",
@@ -74,7 +74,7 @@ describe('noConstantConditionRule', () : void => {
             var y = false ? 1 : 0;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: true ?",
                 "name": "file.ts",
@@ -96,7 +96,7 @@ describe('noConstantConditionRule', () : void => {
             var y = 0 ? 1 : 0;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: 1 ?",
                 "name": "file.ts",
@@ -124,7 +124,7 @@ describe('noConstantConditionRule', () : void => {
             while (true) {}
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: while (false)",
                 "name": "file.ts",
@@ -152,7 +152,7 @@ describe('noConstantConditionRule', () : void => {
             while (1) {}
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: while (0)",
                 "name": "file.ts",
@@ -180,7 +180,7 @@ describe('noConstantConditionRule', () : void => {
             do {} while (false)
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: while (true)",
                 "name": "file.ts",
@@ -208,7 +208,7 @@ describe('noConstantConditionRule', () : void => {
             do {} while (0)
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: while (1)",
                 "name": "file.ts",
@@ -236,7 +236,7 @@ describe('noConstantConditionRule', () : void => {
             for (;false;) { }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: ;true;",
                 "name": "file.ts",
@@ -264,7 +264,7 @@ describe('noConstantConditionRule', () : void => {
             for (;0;) { }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found constant conditional: ;1;",
                 "name": "file.ts",

--- a/tests/NoControlRegexRuleTests.ts
+++ b/tests/NoControlRegexRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -23,7 +23,7 @@ describe('noControlRegexRule', () : void => {
             var pattern6 = new RegExp("\\x20");
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on x1f', () : void => {
@@ -33,7 +33,7 @@ describe('noControlRegexRule', () : void => {
             var pattern3 = RegExp("\\x1f trailing text");
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Unexpected control character in regular expression",
                 "name": "file.ts",
@@ -62,7 +62,7 @@ describe('noControlRegexRule', () : void => {
             var pattern3 = RegExp("\\x00");
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Unexpected control character in regular expression",
                 "name": "file.ts",

--- a/tests/NoCookiesTests.ts
+++ b/tests/NoCookiesTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -12,19 +12,13 @@ describe('noCookiesRule', () : void => {
     it('should not produce violations', () : void => {
         var ruleName : string = 'no-cookies';
         var inputFile : string = 'test-data/NoCookiesPassingTestInput.ts';
-        TestHelper.assertViolations(
-            ruleName,
-            inputFile,
-            [ ]
-        );
+        TestHelper.assertViolations(ruleName, null, inputFile,[ ]);
     });
 
     it('should produce violations', () : void => {
         var ruleName : string = 'no-cookies';
         var inputFile : string = 'test-data/NoCookiesFailingTestInput.ts';
-        TestHelper.assertViolations(
-            ruleName,
-            inputFile,
+        TestHelper.assertViolations(ruleName, null, inputFile,
             [
                 {
                     "failure": "Forbidden call to document.cookie",
@@ -63,9 +57,7 @@ describe('noCookiesRule', () : void => {
     it('should not throw error ', () : void => {
         var ruleName : string = 'no-cookies';
         var inputFile : string = 'test-data/NoCookiesTestInput-error.ts';
-        TestHelper.assertViolations(
-            ruleName,
-            inputFile,
+        TestHelper.assertViolations(ruleName, null, inputFile,
             [
                 {
                     "failure": "Forbidden call to document.cookie",

--- a/tests/NoDeleteExpressionTests.ts
+++ b/tests/NoDeleteExpressionTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,12 +13,12 @@ describe('noDeleteExpressionRule', (): void => {
 
     it('should not produce violations', (): void => {
         const inputFile: string = 'test-data/NoDeleteExpressionPassingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should produce violations ', (): void => {
         const inputFile: string = 'test-data/NoDeleteExpressionFailingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Variables should not be deleted: variableForDeletion",
                 "name": "test-data/NoDeleteExpressionFailingTestInput.ts",

--- a/tests/NoDisableAutoSanitizationTests.ts
+++ b/tests/NoDisableAutoSanitizationTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -12,9 +12,7 @@ describe('noDisableAutoSanitizationRule', () : void => {
     it('should produce violation for execUnsafeLocalFunction', () : void => {
         var ruleName : string = 'no-disable-auto-sanitization';
         var script : string = 'var retVal = MSApp.execUnsafeLocalFunction(() => {});';
-        TestHelper.assertViolations(
-            ruleName,
-            script,
+        TestHelper.assertViolations(ruleName, null,script,
             [
                 {
                     "failure": "Forbidden call to execUnsafeLocalFunction",
@@ -29,9 +27,7 @@ describe('noDisableAutoSanitizationRule', () : void => {
     it('should produce violation for setInnerHTMLUnsafe', () : void => {
         var ruleName : string = 'no-disable-auto-sanitization';
         var script : string = 'WinJS.Utilities.setInnerHTMLUnsafe(element, text);';
-        TestHelper.assertViolations(
-            ruleName,
-            script,
+        TestHelper.assertViolations(ruleName, null,script,
             [
                 {
                     "failure": "Forbidden call to setInnerHTMLUnsafe",

--- a/tests/NoDocumentWriteTests.ts
+++ b/tests/NoDocumentWriteTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,12 +13,12 @@ describe('noDocumentWriteRule', () : void => {
 
     it('should not produce violations ', () : void => {
         var inputFile : string = 'test-data/NoDocumentWritePassingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoDocumentWriteFailingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden call to document.write",
                 "name": "test-data/NoDocumentWriteFailingTestInput.ts",

--- a/tests/NoDuplicateCaseRuleTests.ts
+++ b/tests/NoDuplicateCaseRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -26,7 +26,7 @@ describe('noDuplicateCaseRule', () : void => {
                     break;
             } `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on string duplicates', () : void => {
@@ -43,7 +43,7 @@ describe('noDuplicateCaseRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Duplicate case found in switch statement: 1",
                 "name": "file.ts",
@@ -67,7 +67,7 @@ describe('noDuplicateCaseRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Duplicate case found in switch statement: \"1\"",
                 "name": "file.ts",
@@ -91,7 +91,7 @@ describe('noDuplicateCaseRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Duplicate case found in switch statement: one",
                 "name": "file.ts",

--- a/tests/NoDuplicateParameterNamesTests.ts
+++ b/tests/NoDuplicateParameterNamesTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noDuplicateParameterNames', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoDuplicateParameterNamesTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Duplicate parameter name: 'duplicateConstructorParameter'",
                 "name": "test-data/NoDuplicateParameterNamesTestInput.ts",

--- a/tests/NoEmptyInterfacesRuleTests.ts
+++ b/tests/NoEmptyInterfacesRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -20,7 +20,7 @@ describe('noEmptyInterfacesRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on empty interface', () : void => {
@@ -30,7 +30,7 @@ describe('noEmptyInterfacesRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not declare empty interfaces: 'MyInterface'",
                 "name": "file.ts",

--- a/tests/NoExecScriptTests.ts
+++ b/tests/NoExecScriptTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noExecScriptRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoExecScriptTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "forbidden execScript: execScript",
                 "name": "test-data/NoExecScriptTestInput.ts",

--- a/tests/NoForInRuleTests.ts
+++ b/tests/NoForInRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -20,7 +20,7 @@ describe('noForInRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on for-in statement', () : void => {
@@ -30,7 +30,7 @@ describe('noForInRule', () : void => {
             }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Do not use for in statements, use Object.keys instead: for (name in object)",
                 "name": "file.ts",

--- a/tests/NoFunctionConstructorWithStringArgsTests.ts
+++ b/tests/NoFunctionConstructorWithStringArgsTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noFunctionConstructorWithStringArgsRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoFunctionConstructorWithStringArgsTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "forbidden: Function constructor with string arguments ",
                 "name": "test-data/NoFunctionConstructorWithStringArgsTestInput.ts",

--- a/tests/NoFunctionExpressionRuleTests.ts
+++ b/tests/NoFunctionExpressionRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -19,7 +19,7 @@ describe('noFunctionExpressionRule', () : void => {
 	        }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should pass on function with this', (): void => {
@@ -29,7 +29,7 @@ describe('noFunctionExpressionRule', () : void => {
 	        }
         `;
 
-        TestHelper.assertViolations(ruleName, script, []);
+        TestHelper.assertViolations(ruleName, null, script, []);
     });
 
 
@@ -42,7 +42,7 @@ describe('noFunctionExpressionRule', () : void => {
 	        }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ {
+        TestHelper.assertViolations(ruleName, null, script, [ {
             "failure": "Use arrow function instead of function expression",
             "name": "file.ts",
             "ruleName": "no-function-expression",
@@ -69,7 +69,7 @@ describe('noFunctionExpressionRule', () : void => {
 	        }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Use arrow function instead of function expression",
                 "name": "file.ts",

--- a/tests/NoHttpStringRuleTests.ts
+++ b/tests/NoHttpStringRuleTests.ts
@@ -9,7 +9,7 @@ import TestHelper = require('./utils/TestHelper');
  */
 describe('noHttpStringRule', () : void => {
 
-    var ruleName : string = 'no-http-string';
+    const ruleName : string = 'no-http-string';
 
     it('should ban http strings in variables', () : void => {
         var inputScript : string = 'var x = \'http://www.examples.com\'';
@@ -17,7 +17,7 @@ describe('noHttpStringRule', () : void => {
             {
                 "failure": "Forbidden http url in string: 'http://www.examples.com'",
                 "name": "file.ts",
-                "ruleName": "no-http-string",
+                "ruleName": ruleName,
                 "startPosition": { "character": 9, "line": 1 }
             }
         ]);
@@ -29,13 +29,12 @@ describe('noHttpStringRule', () : void => {
             {
                 "failure": "Forbidden http url in string: 'http://www.example.com/whatever'",
                 "name": "file.ts",
-                "ruleName": "no-http-string",
+                "ruleName": ruleName,
                 "startPosition": { "character": 25, "line": 1 }
             }
         ]);
     });
-
-
+	
     it('should allow https strings in variables', () : void => {
         var inputScript : string = 'var x = \'https://www.microsoft.com\'';
         TestHelper.assertNoViolation(ruleName, null, inputScript);
@@ -44,6 +43,26 @@ describe('noHttpStringRule', () : void => {
     it('should allow https strings in default values', () : void => {
         var inputScript : string = 'function f(x : string = \'https://www.microsoft.com\') {}';
         TestHelper.assertNoViolation(ruleName, null, inputScript);
+    });
+
+	it('should allow http strings in that match the exclude regex', (): void => {
+        var inputScript: string = 'var x = "http://www.allowed.com"';
+		var excludeRules = ["http://www\\.allowed\\.com/?"];
+        TestHelper.assertNoViolation(ruleName, excludeRules, inputScript);
+    });
+
+	it('should disallow http strings in that do not match the exclude regex', (): void => {
+        var inputScript: string = 'var x = "http://www.notallowed.com"';
+		var excludeRules = ["http://www\\.allowed\\.com/?"];
+        TestHelper.assertViolations(ruleName, excludeRules, inputScript, [{
+			"failure": "Forbidden http url in string: 'http://www.notallowed.com'",
+			"name": "file.ts",
+			"ruleName": ruleName,
+			"startPosition": {
+				"character": 9,
+				"line": 1
+			}
+		}]);
     });
 
 });

--- a/tests/NoHttpStringRuleTests.ts
+++ b/tests/NoHttpStringRuleTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noHttpStringRule', () : void => {
 
     it('should ban http strings in variables', () : void => {
         var inputScript : string = 'var x = \'http://www.examples.com\'';
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Forbidden http url in string: 'http://www.examples.com'",
                 "name": "file.ts",
@@ -25,7 +25,7 @@ describe('noHttpStringRule', () : void => {
 
     it('should ban http strings in default values', () : void => {
         var inputScript : string = 'function f(x : string = \'http://www.example.com/whatever\') {}';
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Forbidden http url in string: 'http://www.example.com/whatever'",
                 "name": "file.ts",
@@ -38,12 +38,12 @@ describe('noHttpStringRule', () : void => {
 
     it('should allow https strings in variables', () : void => {
         var inputScript : string = 'var x = \'https://www.microsoft.com\'';
-        TestHelper.assertViolations(ruleName, inputScript, []);
+        TestHelper.assertNoViolation(ruleName, null, inputScript);
     });
 
     it('should allow https strings in default values', () : void => {
         var inputScript : string = 'function f(x : string = \'https://www.microsoft.com\') {}';
-        TestHelper.assertViolations(ruleName, inputScript, []);
+        TestHelper.assertNoViolation(ruleName, null, inputScript);
     });
 
 });

--- a/tests/NoIncrementDecrementTests.ts
+++ b/tests/NoIncrementDecrementTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noIncrementDecrementRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoIncrementDecrementTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden ++ operator",
                 "name": "test-data/NoIncrementDecrementTestInput.ts",

--- a/tests/NoInvalidRegexpRuleTests.ts
+++ b/tests/NoInvalidRegexpRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -21,7 +21,7 @@ describe('noInvalidRegexpRule', () : void => {
             var d = new RegExp(whatever);   // non-string literal parameter
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on invalid string in constuctor', () : void => {
@@ -29,7 +29,7 @@ describe('noInvalidRegexpRule', () : void => {
             new RegExp('\\\\') /*error Invalid regular expression: /\/: \ at end of pattern*/
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid regular expression: /\\/: \\ at end of pattern",
                 "name": "file.ts",
@@ -44,7 +44,7 @@ describe('noInvalidRegexpRule', () : void => {
             RegExp('[')      /*error Invalid regular expression: /[/: Unterminated character class*/
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid regular expression: /[/: Unterminated character class",
                 "name": "file.ts",

--- a/tests/NoMissingVisibilityModifiersRuleTests.ts
+++ b/tests/NoMissingVisibilityModifiersRuleTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -23,7 +23,7 @@ class {
     public static myField6;
 }`;
 
-        TestHelper.assertViolations(ruleName, inputScript, []);
+        TestHelper.assertViolations(ruleName, null, inputScript, []);
     });
 
     it('should allow method modifiers', () : void => {
@@ -37,7 +37,7 @@ class {
     public static myMethod6() {};
 }`;
 
-        TestHelper.assertViolations(ruleName, inputScript, []);
+        TestHelper.assertViolations(ruleName, null, inputScript, []);
     });
 
     it('should not allow missing field modifiers', () : void => {
@@ -47,7 +47,7 @@ class {
     static myField2;
 }`;
 
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Field missing visibility modifier: myField1;",
                 "name": "file.ts",
@@ -71,7 +71,7 @@ class {
     static myMethod2() {};
 }`;
 
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Method missing visibility modifier: myMethod1() {",
                 "name": "file.ts",

--- a/tests/NoMultilineStringTests.ts
+++ b/tests/NoMultilineStringTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noMultilineStringRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoMultilineStringTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden Multiline string:  `some...",
                 "name": "test-data/NoMultilineStringTestInput.ts",

--- a/tests/NoMultipleVarDeclRuleTests.ts
+++ b/tests/NoMultipleVarDeclRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -21,7 +21,7 @@ describe('noMultipleVarDeclRule', () : void => {
             for (var i = x, j = y; i < j; i++) {}
         `;
 
-        TestHelper.assertNoViolation(ruleName, script);
+        TestHelper.assertNoViolation(ruleName, null, script);
     });
 
     it('should fail on multiple var declaration', () : void => {
@@ -31,7 +31,7 @@ describe('noMultipleVarDeclRule', () : void => {
             var x, y = 2, z;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [{
+        TestHelper.assertViolations(ruleName, null, script, [{
             "failure": "Do not use comma separated variable declarations: x = 1,",
             "name": "file.ts",
             "ruleName": "no-multiple-var-decl",

--- a/tests/NoOctalLiteralTests.ts
+++ b/tests/NoOctalLiteralTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /* tslint:disable:no-octal-literal */
 /**
@@ -23,7 +23,7 @@ function demoScriptPass1() {
     var y = "Sample text \0111"; // longer than octal
 }`;
 
-         TestHelper.assertViolations(ruleName, script, [ ]);
+         TestHelper.assertViolations(ruleName, null, script, [ ]);
      });
 
      it('should fail on 3 digit octal literals', () : void => {
@@ -38,12 +38,12 @@ function demoScriptFail() {
     var d = 'Sample text \354 more text';
 }`;
 
-         TestHelper.assertViolations(ruleName, script, [ ]);
+         TestHelper.assertViolations(ruleName, null, script, [ ]);
      });
 
      it('should produce violations ', () : void => {
          var inputFile : string = 'test-data/NoOctalLiteralTestInput.ts';
-         TestHelper.assertViolations(ruleName, inputFile, [
+         TestHelper.assertViolations(ruleName, null, inputFile, [
              {
                  "failure": "Octal literals should not be used: \\251",
                  "name": "test-data/NoOctalLiteralTestInput.ts",

--- a/tests/NoRegexSpacesRuleTests.ts
+++ b/tests/NoRegexSpacesRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -18,7 +18,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = /foo {3}bar/;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should pass on RegExp object', () : void => {
@@ -26,7 +26,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = new RegExp("foo   bar");
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should pass on no spaces', () : void => {
@@ -34,7 +34,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = /foobar/;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on spaces in middle', () : void => {
@@ -42,7 +42,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = /foo   bar/;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Spaces in regular expressions are hard to count. Use {3}",
                 "name": "file.ts",
@@ -57,7 +57,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = /  bar/;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Spaces in regular expressions are hard to count. Use {2}",
                 "name": "file.ts",
@@ -72,7 +72,7 @@ describe('noRegexSpacesRule', () : void => {
             var re = /bar    /;
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Spaces in regular expressions are hard to count. Use {4}",
                 "name": "file.ts",

--- a/tests/NoReservedKeywordsTests.ts
+++ b/tests/NoReservedKeywordsTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -15,7 +15,7 @@ describe('noBannedTermsRule', () : void => {
 
     it('should not allow the break reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-break.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: break",
                 "name": "test-data/NoReservedKeywordsTestInput-break.ts",
@@ -74,7 +74,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the case reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-case.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [  {
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [  {
             "failure": "Forbidden reference to reserved keyword: case",
             "name": "test-data/NoReservedKeywordsTestInput-case.ts",
             "ruleName": "no-reserved-keywords",
@@ -132,7 +132,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the catch reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-catch.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: catch",
                 "name": "test-data/NoReservedKeywordsTestInput-catch.ts",
@@ -191,7 +191,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the class reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-class.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: class",
                 "name": "test-data/NoReservedKeywordsTestInput-class.ts",
@@ -223,7 +223,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the const reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-const.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: const",
                 "name": "test-data/NoReservedKeywordsTestInput-const.ts",
@@ -282,7 +282,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the continue reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-continue.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: continue",
                 "name": "test-data/NoReservedKeywordsTestInput-continue.ts",
@@ -341,7 +341,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the debugger reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-debugger.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: debugger",
                 "name": "test-data/NoReservedKeywordsTestInput-debugger.ts",
@@ -400,7 +400,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the default reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-default.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: default",
                 "name": "test-data/NoReservedKeywordsTestInput-default.ts",
@@ -459,7 +459,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the delete reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-delete.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: delete",
                 "name": "test-data/NoReservedKeywordsTestInput-delete.ts",
@@ -518,7 +518,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the do reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-do.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: do",
                 "name": "test-data/NoReservedKeywordsTestInput-do.ts",
@@ -577,7 +577,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the else reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-else.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: else",
                 "name": "test-data/NoReservedKeywordsTestInput-else.ts",
@@ -636,7 +636,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the enum reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-enum.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: enum",
                 "name": "test-data/NoReservedKeywordsTestInput-enum.ts",
@@ -695,7 +695,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the export reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-export.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: export",
                 "name": "test-data/NoReservedKeywordsTestInput-export.ts",
@@ -754,7 +754,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the extends reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-extends.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: extends",
                 "name": "test-data/NoReservedKeywordsTestInput-extends.ts",
@@ -813,7 +813,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the false reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-false.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: false",
                 "name": "test-data/NoReservedKeywordsTestInput-false.ts",
@@ -872,7 +872,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the finally reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-finally.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: finally",
                 "name": "test-data/NoReservedKeywordsTestInput-finally.ts",
@@ -931,7 +931,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the for reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-for.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: for",
                 "name": "test-data/NoReservedKeywordsTestInput-for.ts",
@@ -990,7 +990,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the function reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-function.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: function",
                 "name": "test-data/NoReservedKeywordsTestInput-function.ts",
@@ -1049,7 +1049,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the if reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-if.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: if",
                 "name": "test-data/NoReservedKeywordsTestInput-if.ts",
@@ -1108,7 +1108,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the import in reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-import.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: import",
                 "name": "test-data/NoReservedKeywordsTestInput-import.ts",
@@ -1167,7 +1167,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the instanceof reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-instanceof.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: instanceof",
                 "name": "test-data/NoReservedKeywordsTestInput-instanceof.ts",
@@ -1226,7 +1226,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the new reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-new.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: new",
                 "name": "test-data/NoReservedKeywordsTestInput-new.ts",
@@ -1285,7 +1285,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the null reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-null.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: null",
                 "name": "test-data/NoReservedKeywordsTestInput-null.ts",
@@ -1344,7 +1344,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the return reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-return.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: return",
                 "name": "test-data/NoReservedKeywordsTestInput-return.ts",
@@ -1403,7 +1403,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the super reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-super.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: super",
                 "name": "test-data/NoReservedKeywordsTestInput-super.ts",
@@ -1462,7 +1462,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the switch reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-switch.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: switch",
                 "name": "test-data/NoReservedKeywordsTestInput-switch.ts",
@@ -1521,7 +1521,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the this reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-this.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: this",
                 "name": "test-data/NoReservedKeywordsTestInput-this.ts",
@@ -1580,7 +1580,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the throw reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-throw.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: throw",
                 "name": "test-data/NoReservedKeywordsTestInput-throw.ts",
@@ -1639,7 +1639,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the true reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-true.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: true",
                 "name": "test-data/NoReservedKeywordsTestInput-true.ts",
@@ -1698,7 +1698,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the try reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-try.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: try",
                 "name": "test-data/NoReservedKeywordsTestInput-try.ts",
@@ -1757,7 +1757,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the typeof reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-typeof.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: typeof",
                 "name": "test-data/NoReservedKeywordsTestInput-typeof.ts",
@@ -1816,7 +1816,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the var reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-var.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: var",
                 "name": "test-data/NoReservedKeywordsTestInput-var.ts",
@@ -1875,7 +1875,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the void reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-void.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: void",
                 "name": "test-data/NoReservedKeywordsTestInput-void.ts",
@@ -1934,7 +1934,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the while reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-while.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: while",
                 "name": "test-data/NoReservedKeywordsTestInput-while.ts",
@@ -1993,7 +1993,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the with reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-with.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: with",
                 "name": "test-data/NoReservedKeywordsTestInput-with.ts",
@@ -2052,7 +2052,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the as reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-as.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: as",
                 "name": "test-data/NoReservedKeywordsTestInput-as.ts",
@@ -2165,7 +2165,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the implements reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-implements.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: implements",
                 "name": "test-data/NoReservedKeywordsTestInput-implements.ts",
@@ -2260,7 +2260,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the interface reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-interface.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: interface",
                 "name": "test-data/NoReservedKeywordsTestInput-interface.ts",
@@ -2355,7 +2355,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the let reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-let.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: let",
                 "name": "test-data/NoReservedKeywordsTestInput-let.ts",
@@ -2450,7 +2450,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the package reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-package.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: package",
                 "name": "test-data/NoReservedKeywordsTestInput-package.ts",
@@ -2545,7 +2545,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the private reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-private.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: private",
                 "name": "test-data/NoReservedKeywordsTestInput-private.ts",
@@ -2640,7 +2640,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the protected reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-protected.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: protected",
                 "name": "test-data/NoReservedKeywordsTestInput-protected.ts",
@@ -2735,7 +2735,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the public reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-public.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: public",
                 "name": "test-data/NoReservedKeywordsTestInput-public.ts",
@@ -2830,7 +2830,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the static reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-static.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: static",
                 "name": "test-data/NoReservedKeywordsTestInput-static.ts",
@@ -2925,7 +2925,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the yield reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-yield.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: yield",
                 "name": "test-data/NoReservedKeywordsTestInput-yield.ts",
@@ -3020,7 +3020,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the any reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-any.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: any",
                 "name": "test-data/NoReservedKeywordsTestInput-any.ts",
@@ -3133,7 +3133,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the boolean reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-boolean.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: boolean",
                 "name": "test-data/NoReservedKeywordsTestInput-boolean.ts",
@@ -3246,7 +3246,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the constructor reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-constructor.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: constructor",
                 "name": "test-data/NoReservedKeywordsTestInput-constructor.ts",
@@ -3341,7 +3341,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the declare reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-declare.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: declare",
                 "name": "test-data/NoReservedKeywordsTestInput-declare.ts",
@@ -3454,7 +3454,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the get reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-get.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: get",
                 "name": "test-data/NoReservedKeywordsTestInput-get.ts",
@@ -3567,7 +3567,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the module reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-module.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: module",
                 "name": "test-data/NoReservedKeywordsTestInput-module.ts",
@@ -3671,7 +3671,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the require reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-require.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: require",
                 "name": "test-data/NoReservedKeywordsTestInput-require.ts",
@@ -3775,7 +3775,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the number reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-number.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: number",
                 "name": "test-data/NoReservedKeywordsTestInput-number.ts",
@@ -3888,7 +3888,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the set reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-set.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: set",
                 "name": "test-data/NoReservedKeywordsTestInput-set.ts",
@@ -4001,7 +4001,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the string reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-string.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: string",
                 "name": "test-data/NoReservedKeywordsTestInput-string.ts",
@@ -4114,7 +4114,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the symbol reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-symbol.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: symbol",
                 "name": "test-data/NoReservedKeywordsTestInput-symbol.ts",
@@ -4227,7 +4227,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the type reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-type.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: type",
                 "name": "test-data/NoReservedKeywordsTestInput-type.ts",
@@ -4340,7 +4340,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the from reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-from.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: from",
                 "name": "test-data/NoReservedKeywordsTestInput-from.ts",
@@ -4453,7 +4453,7 @@ describe('noBannedTermsRule', () : void => {
     });
     it('should not allow the of reserved word', () : void => {
         var inputFile : string = 'test-data/NoReservedKeywordsTestInput-of.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden reference to reserved keyword: of",
                 "name": "test-data/NoReservedKeywordsTestInput-of.ts",
@@ -4567,7 +4567,7 @@ describe('noBannedTermsRule', () : void => {
 
 
     it('should not allow local variable named require', () : void => {
-        TestHelper.assertViolations(RULE_NAME,
+        TestHelper.assertViolations(RULE_NAME, null,
             `var require`,
             [  {
                 "failure": "Forbidden reference to reserved keyword: require",
@@ -4578,7 +4578,7 @@ describe('noBannedTermsRule', () : void => {
     });
 
     it('should not allow local variable named module', () : void => {
-        TestHelper.assertViolations(RULE_NAME,
+        TestHelper.assertViolations(RULE_NAME, null,
             `var module`,
             [  {
                 "failure": "Forbidden reference to reserved keyword: module",

--- a/tests/NoSparseArraysRuleTests.ts
+++ b/tests/NoSparseArraysRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -22,7 +22,7 @@ describe('noSparseArraysRule', () : void => {
             var e = [1,2,3,]; // dangling comma is not an issue
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on comma with no elements', () : void => {
@@ -30,7 +30,7 @@ describe('noSparseArraysRule', () : void => {
             var x = [,];
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Unexpected comma in middle of array",
                 "name": "file.ts",
@@ -45,7 +45,7 @@ describe('noSparseArraysRule', () : void => {
             var x = [,,,];
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Unexpected comma in middle of array",
                 "name": "file.ts",
@@ -61,7 +61,7 @@ describe('noSparseArraysRule', () : void => {
             var z = [1,,2,3];
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Unexpected comma in middle of array",
                 "name": "file.ts",

--- a/tests/NoStringBasedSetImmediateTests.ts
+++ b/tests/NoStringBasedSetImmediateTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noStringBasedSetImmediateRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetImmediateTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setImmediate string parameter: \"var x = 'should fail'\"",
                 "name": "test-data/NoStringBasedSetImmediateTestInput.ts",

--- a/tests/NoStringBasedSetIntervalTests.ts
+++ b/tests/NoStringBasedSetIntervalTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,7 +13,7 @@ describe('noStringBasedSetIntervalRule', () : void => {
 
     it('should produce violations ', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetIntervalTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setInterval string parameter: \"var x = 'should fail'\"",
                 "name": "test-data/NoStringBasedSetIntervalTestInput.ts",

--- a/tests/NoStringBasedSetTimeoutTests.ts
+++ b/tests/NoStringBasedSetTimeoutTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -14,17 +14,17 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should not throw error - case 1', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-error.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should not throw error - case 2', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-error2.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should support type inference on shadowed variables', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-shadow-vars.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: moduleProp1",
                 "name": "test-data/NoStringBasedSetTimeoutTestInput-shadow-vars.ts",
@@ -96,12 +96,12 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should not throw error - case 3', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-error3.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should not throw error - case 4', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-error4.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: this.onAnimationEnd()",
                 "name": "test-data/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -113,17 +113,17 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should not throw error - case 5', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutTestInput-error5.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should not produce violations', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutPassingTestInput.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, []);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, []);
     });
 
     it('should produce violations for string literals', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "ruleName": "no-string-based-set-timeout",
                 "failure": "Forbidden setTimeout string parameter: \"var x = 'should fail'\"",
@@ -147,7 +147,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should produce violations for string variables', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "ruleName": "no-string-based-set-timeout",
                 "failure": "Forbidden setTimeout string parameter: typedStringVariable",
@@ -172,7 +172,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should produce violations for any variables', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "ruleName": "no-string-based-set-timeout",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -196,7 +196,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should produce violations for any functions', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: untypedCreateFunction()",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -220,7 +220,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should produce violations for string functions', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: stringFunction()",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -244,7 +244,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
 
     it('should produce violations for parameters', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-parameters.ts';
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: stringArg",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-parameters.ts",
@@ -267,7 +267,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
             setTimeout(functionArg2);
         }`;
 
-        TestHelper.assertViolations(RULE_NAME, inputFile, [ ]);
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [ ]);
     });
 
     it('should not fail within a constructor', () : void => {
@@ -278,7 +278,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
             }
         }`;
 
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: arg1",
                 "name": "file.ts",
@@ -291,7 +291,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
     it('should create violations on template strings', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-template-string.ts';
 
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: `${data}`",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-template-string.ts",
@@ -304,7 +304,7 @@ describe('noStringBasedSetTimeoutRule', () : void => {
     it('should pass all Issue #46 usages', () : void => {
         var inputFile : string = 'test-data/NoStringBasedSetTimeoutFailingTestInput-issue46.ts';
 
-        TestHelper.assertViolations(RULE_NAME, inputFile, [
+        TestHelper.assertViolations(RULE_NAME, null, inputFile, [
             {
                 "failure": "Forbidden setTimeout string parameter: \"alert(\" + alertNum + \")\"",
                 "name": "test-data/NoStringBasedSetTimeoutFailingTestInput-issue46.ts",

--- a/tests/NoUnnecessaryBindRuleTests.ts
+++ b/tests/NoUnnecessaryBindRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -22,7 +22,7 @@ describe('noUnnecessaryBindRule', () : void => {
             (someReference).bind(this, someArg);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on function/lambda literals with non-this parameter', () : void => {
@@ -32,7 +32,7 @@ describe('noUnnecessaryBindRule', () : void => {
             (someReference).bind(context);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore static invocation with no context', () : void => {
@@ -42,7 +42,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _.forEach(list, someReference);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore invocation with no context', () : void => {
@@ -52,7 +52,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _(list).collect(someReference);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore static invocation with context', () : void => {
@@ -63,7 +63,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _.map(list, someReference, context);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore invocation with context', () : void => {
@@ -73,7 +73,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _(list).map(someReference, context);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on "this" context with non-literal function', () : void => {
@@ -83,7 +83,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _.reject(list, someReference, this);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on _.sortedIndex', () : void => {
@@ -96,7 +96,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _.sortedIndex(function () {}, value, someReference, this);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore static invocation with unknown method', () : void => {
@@ -105,7 +105,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _.not_an_underscore_function(list, () => {}, this);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('should pass on underscore invocation with unknown method', () : void => {
@@ -113,7 +113,7 @@ describe('noUnnecessaryBindRule', () : void => {
             _(list).not_an_underscore_function(function() {}, context);
             _(list).not_an_underscore_function(() => {}, context);
         `;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
     });
@@ -125,7 +125,7 @@ describe('noUnnecessaryBindRule', () : void => {
             (function() {}).bind(this);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -140,7 +140,7 @@ describe('noUnnecessaryBindRule', () : void => {
             (() => {}).bind(this);
         `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -155,7 +155,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.map(list, function() {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -170,7 +170,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.map(list, () => {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -184,7 +184,7 @@ describe('noUnnecessaryBindRule', () : void => {
             var script : string = `
                 _(list).forEach(function() {}, this);
             `;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -198,7 +198,7 @@ describe('noUnnecessaryBindRule', () : void => {
             var script : string = `
                 _(list).every(() => {}, this);
             `;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -214,7 +214,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.reduce(list, function () {}, memo, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [  {
+            TestHelper.assertViolations(ruleName, null, script, [  {
                 "failure": "Binding function literal with 'this' context. Use lambdas instead",
                 "name": "file.ts",
                 "ruleName": "no-unnecessary-bind",
@@ -229,7 +229,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.reduce(list, () => {}, memo, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -245,7 +245,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _(list).reduce(function () {}, memo, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -261,7 +261,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _(list).reduce(() => {}, memo, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -277,7 +277,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.sortedIndex(list, value, function () {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -293,7 +293,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.sortedIndex(list, value, () => {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -309,7 +309,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _(list).sortedIndex(value, function () {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -325,7 +325,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _(list).sortedIndex(value, () => {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",
@@ -340,7 +340,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.bind(function () {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding function literal with 'this' context. Use lambdas instead",
                     "name": "file.ts",
@@ -355,7 +355,7 @@ describe('noUnnecessaryBindRule', () : void => {
                 _.bind(() => {}, this);
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Binding lambda with 'this' context. Lambdas already have 'this' bound",
                     "name": "file.ts",

--- a/tests/NoUnnecessarySemicolonsTests.ts
+++ b/tests/NoUnnecessarySemicolonsTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -12,9 +12,7 @@ describe('noUnnecessarySemiColons', () : void => {
     it('should produce violations', () : void => {
         var ruleName : string = 'no-unnecessary-semicolons';
         var inputFile : string = 'test-data/NoUnnecessarySemicolonsTestInput.ts';
-        TestHelper.assertViolations(
-            ruleName,
-            inputFile,
+        TestHelper.assertViolations(ruleName, null, inputFile,
             [
                 {
                     "failure": "unnecessary semi-colon",

--- a/tests/NoUnusedImportsTests.ts
+++ b/tests/NoUnusedImportsTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -14,8 +14,7 @@ describe('noUnusedImportsRule', () : void => {
         var ruleName : string = 'no-unused-imports';
         var inputFile : string = 'test-data/NoUnusedImportsTestInput.ts';
         TestHelper.assertViolations(
-            ruleName,
-            inputFile,
+            ruleName, null, inputFile,
             [
                 {
                     "failure": "unused import: 'NoUnusedImportsRule'",
@@ -34,7 +33,7 @@ import DM = require("DM");
 import AB = DM.Dependency;
 console.log(DM);`; // AB import is not used!
 
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "unused import: 'AB'",
                 "name": "file.ts",
@@ -51,7 +50,7 @@ import DM = require("DM");
 import AB = DM.Dependency;
 console.log(AB);`;
 
-        TestHelper.assertViolations(ruleName, inputScript, []);
+        TestHelper.assertViolations(ruleName, null, inputScript, []);
     });
 
 });

--- a/tests/NoWithStatementTests.ts
+++ b/tests/NoWithStatementTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -19,7 +19,7 @@ describe('noWithStatementsRule', () : void => {
                 b = 2;
             }
         `;
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "Forbidden with statement",
                     "name": "file.ts",

--- a/tests/PromiseMustCompleteRuleTests.ts
+++ b/tests/PromiseMustCompleteRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -29,7 +29,7 @@ describe('promiseMustCompleteRule', () : void => {
                     }
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('on resolve - lambda', () : void => {
@@ -38,7 +38,7 @@ describe('promiseMustCompleteRule', () : void => {
                     resolve('value');
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on resolve - function', () : void => {
@@ -47,7 +47,7 @@ describe('promiseMustCompleteRule', () : void => {
                     resolve('value');
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on resolve - alternative name', () : void => {
@@ -56,7 +56,7 @@ describe('promiseMustCompleteRule', () : void => {
                     someOtherName('value');
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on reject', () : void => {
@@ -65,7 +65,7 @@ describe('promiseMustCompleteRule', () : void => {
                     reject('value);
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on reject - function', () : void => {
@@ -74,7 +74,7 @@ describe('promiseMustCompleteRule', () : void => {
                     reject('value);
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on reject - alternative name', () : void => {
@@ -83,7 +83,7 @@ describe('promiseMustCompleteRule', () : void => {
                     someOtherName('value);
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('when single branch is completed - with if-statement', () : void => {
@@ -94,7 +94,7 @@ describe('promiseMustCompleteRule', () : void => {
                     }
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when single branch is completed - with if-else-statement', () : void => {
@@ -107,7 +107,7 @@ describe('promiseMustCompleteRule', () : void => {
                     }
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when single branch is completed - with if-else-statement', () : void => {
@@ -127,7 +127,7 @@ describe('promiseMustCompleteRule', () : void => {
                         }
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('with nested if-else statement', () : void => {
@@ -148,7 +148,7 @@ describe('promiseMustCompleteRule', () : void => {
                         reject(); // branches are not even analyzed when main thread resolves
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a function', () : void => {
@@ -158,7 +158,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a lambda', () : void => {
@@ -168,7 +168,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a lambda - with extra parameter', () : void => {
@@ -178,7 +178,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a for loop', () : void => {
@@ -188,7 +188,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a for in loop', () : void => {
@@ -198,7 +198,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a while loop', () : void => {
@@ -208,7 +208,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve();
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolve reference escaped into a function call', () : void => {
@@ -216,7 +216,7 @@ describe('promiseMustCompleteRule', () : void => {
                 new Promise<string>((resolve, reject) => {
                     doSomething(resolve); // reference escapes and we assume it resolves
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when reject reference escaped into a function call', () : void => {
@@ -224,7 +224,7 @@ describe('promiseMustCompleteRule', () : void => {
                 new Promise<string>((resolve, reject) => {
                     doSomething(reject); // reference escapes and we assume it resolves
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when non-shadowed parameter resolves within a function', () : void => {
@@ -234,7 +234,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when non-shadowed parameter rejects within a function', () : void => {
@@ -244,7 +244,7 @@ describe('promiseMustCompleteRule', () : void => {
                         reject();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when non-shadowed parameter resolves within a lambda', () : void => {
@@ -254,7 +254,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when non-shadowed parameter rejects within a lambda', () : void => {
@@ -264,7 +264,7 @@ describe('promiseMustCompleteRule', () : void => {
                         reject();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
     });
@@ -276,7 +276,7 @@ describe('promiseMustCompleteRule', () : void => {
                 new Promise<string>(() => {
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -291,7 +291,7 @@ describe('promiseMustCompleteRule', () : void => {
                 new Promise<string>(function {
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -306,7 +306,7 @@ describe('promiseMustCompleteRule', () : void => {
                 new Promise<string>((resolve, reject) => {
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -324,7 +324,7 @@ describe('promiseMustCompleteRule', () : void => {
                     }
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -344,7 +344,7 @@ describe('promiseMustCompleteRule', () : void => {
                     }
                 })`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -371,7 +371,7 @@ describe('promiseMustCompleteRule', () : void => {
                         }
                     }
                 })`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -388,7 +388,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -405,7 +405,7 @@ describe('promiseMustCompleteRule', () : void => {
                         reject();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -422,7 +422,7 @@ describe('promiseMustCompleteRule', () : void => {
                         resolve('value');
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",
@@ -439,7 +439,7 @@ describe('promiseMustCompleteRule', () : void => {
                         reject();
                     });
                 })`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A Promise was found that appears to not have resolve or reject invoked on all code paths",
                     "name": "file.ts",

--- a/tests/ReactNoDangerousHtmlRuleTests.ts
+++ b/tests/ReactNoDangerousHtmlRuleTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 import reactNoDangerousHtmlRule = require('../src/reactNoDangerousHtmlRule');
 
 var dangerousScript : string = `
@@ -38,8 +38,7 @@ describe('reactNoDangerousHtmlRule', () : void => {
     it('should produce violation when function called with no suppression', () : void => {
         exceptions.length = 0;
         TestHelper.assertViolations(
-            ruleName,
-            dangerousScript,
+            ruleName,null, dangerousScript,
             [
                 {
                     "failure": "Invalid call to dangerouslySetInnerHTML in method \"render\"\n" +
@@ -57,12 +56,7 @@ describe('reactNoDangerousHtmlRule', () : void => {
 
     it('should not produce violation when call exists in exception list', () : void => {
         exceptions.push({ file: 'file.ts', method: 'render', comment: 'this usage is OK' });
-
-        TestHelper.assertViolations(
-            ruleName,
-            dangerousScript,
-            []
-        );
+        TestHelper.assertViolations(ruleName,null,dangerousScript,[]);
     });
 });
 /* tslint:enable:quotemark */

--- a/tests/UseIsnanRuleTests.ts
+++ b/tests/UseIsnanRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -19,7 +19,7 @@ describe('useIsnanRule', () : void => {
         if (isNaN(something)) { }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on equality NaN', () : void => {
@@ -30,7 +30,7 @@ describe('useIsnanRule', () : void => {
         if (NaN !== foo) {  }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found an invalid comparison for NaN: foo == NaN",
                 "name": "file.ts",
@@ -66,7 +66,7 @@ describe('useIsnanRule', () : void => {
         if (NaN <= foo) { }
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Found an invalid comparison for NaN: foo > NaN",
                 "name": "file.ts",

--- a/tests/UseNamedParameterRuleTests.ts
+++ b/tests/UseNamedParameterRuleTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -18,7 +18,7 @@ function add() {
     return arguments[0] + arguments[1];
 }`;
 
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Use a named parameter instead: 'arguments[0]'",
                 "name": "file.ts",
@@ -39,7 +39,7 @@ function add() {
 function add() {
     return arguments[whatever()] + arguments[n];
 }`;
-        TestHelper.assertViolations(ruleName, inputScript, [ ]);
+        TestHelper.assertViolations(ruleName, null, inputScript, [ ]);
     });
 
 

--- a/tests/ValidTypeofRuleTests.ts
+++ b/tests/ValidTypeofRuleTests.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
 
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -32,7 +32,7 @@ describe('validTypeofRule', () : void => {
             typeof Symbol.iterator === "symbol"
         `;
 
-        TestHelper.assertViolations(ruleName, script, [ ]);
+        TestHelper.assertViolations(ruleName, null, script, [ ]);
     });
 
     it('should fail on invalid string with ===', () : void => {
@@ -41,7 +41,7 @@ describe('validTypeofRule', () : void => {
             "strnig" === typeof foo
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid comparison in typeof. Did you mean string?",
                 "name": "file.ts",
@@ -64,7 +64,7 @@ describe('validTypeofRule', () : void => {
             "fction" == typeof foo
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid comparison in typeof. Did you mean function?",
                 "name": "file.ts",
@@ -86,7 +86,7 @@ describe('validTypeofRule', () : void => {
             "ndefined" !== typeof foo
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid comparison in typeof. Did you mean undefined?",
                 "name": "file.ts",
@@ -108,7 +108,7 @@ describe('validTypeofRule', () : void => {
             "bollen" != typeof foo
         `;
 
-        TestHelper.assertViolations(ruleName, script, [
+        TestHelper.assertViolations(ruleName, null, script, [
             {
                 "failure": "Invalid comparison in typeof. Did you mean boolean?",
                 "name": "file.ts",

--- a/tests/jqueryDeferredMustCompleteRuleTests.ts
+++ b/tests/jqueryDeferredMustCompleteRuleTests.ts
@@ -3,7 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -30,7 +30,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 return deferred.promise();
             }`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when deferred named jquery completes - let declaration', () : void => {
@@ -49,7 +49,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 return deferred.promise();
             }`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when deferred named $ completes', () : void => {
@@ -69,7 +69,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('on resolve', () : void => {
@@ -81,7 +81,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('on reject', () : void => {
@@ -93,7 +93,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, []);
+            TestHelper.assertViolations(ruleName, null, script, []);
         });
 
         it('when single branch is completed - with if-statement', () : void => {
@@ -107,7 +107,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when single branch is completed - with if-else-statement', () : void => {
@@ -122,7 +122,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 return deferred.promise();
             }`;
 
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when single branch is completed - with if-else-statement', () : void => {
@@ -144,7 +144,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('with nested if-else statement', () : void => {
@@ -167,7 +167,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a function', () : void => {
@@ -179,7 +179,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a lambda', () : void => {
@@ -191,7 +191,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a function', () : void => {
@@ -203,7 +203,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a lambda', () : void => {
@@ -215,7 +215,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a for loop', () : void => {
@@ -227,7 +227,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a for in loop', () : void => {
@@ -239,7 +239,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when resolved within a while loop', () : void => {
@@ -251,7 +251,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
 
         it('when deferred reference escaped into a function call', () : void => {
@@ -261,7 +261,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 doSomething(deferred); // reference escapes and we assume it resolves
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [ ]);
+            TestHelper.assertViolations(ruleName, null, script, [ ]);
         });
     });
 
@@ -275,7 +275,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = $.Deferred<void>()'",
@@ -295,7 +295,7 @@ describe('jquery-deferred-must-complete', () : void => {
             }
             `;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred = $.Deferred<void>()'",
@@ -316,7 +316,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 return deferred.promise();
             }`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = jquery.Deferred<void>()'",
@@ -339,7 +339,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 return deferred.promise();
             }`;
 
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = jquery.Deferred<void>()'",
@@ -369,7 +369,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 }
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = jquery.Deferred<void>()'",
@@ -389,7 +389,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = jquery.Deferred<void>()'",
@@ -409,7 +409,7 @@ describe('jquery-deferred-must-complete', () : void => {
                 });
                 return deferred.promise();
             }`;
-            TestHelper.assertViolations(ruleName, script, [
+            TestHelper.assertViolations(ruleName, null, script, [
                 {
                     "failure": "A JQuery deferred was found that appears to not have resolve or reject invoked on all code paths: " +
                                 "'deferred: JQueryDeferred<void> = jquery.Deferred<void>()'",

--- a/tests/preferArrayLiteralRuleTests.ts
+++ b/tests/preferArrayLiteralRuleTests.ts
@@ -2,7 +2,7 @@
 /// <reference path="../typings/chai.d.ts" />
 
 /* tslint:disable:quotemark */
-import TestHelper = require('./TestHelper');
+import TestHelper = require('./utils/TestHelper');
 
 /**
  * Unit tests.
@@ -13,13 +13,13 @@ describe('preferArrayLiteralRule', () : void => {
 
     it('should allow string[] as variable type', () : void => {
         var inputScript : string = 'var x : string[];';
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
         ]);
     });
 
     it('should ban Array<string> as variable type', () : void => {
         var inputScript : string = 'var x : Array<string>;';
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Replace generic-typed Array with array literal: Array<string>",
                 "name": "file.ts",
@@ -31,7 +31,7 @@ describe('preferArrayLiteralRule', () : void => {
 
     it('should ban Array<string> as parameter type', () : void => {
         var inputScript : string = 'function (parm: Array<number>) {}';
-        TestHelper.assertViolations(ruleName, inputScript, [
+        TestHelper.assertViolations(ruleName, null, inputScript, [
             {
                 "failure": "Replace generic-typed Array with array literal: Array<number>",
                 "name": "file.ts",

--- a/tests/utils/TestHelper.ts
+++ b/tests/utils/TestHelper.ts
@@ -49,7 +49,7 @@ module TestHelper {
 
         var linter: Lint.Linter;
         if (inputFileOrScript.match(/.*\.ts/)) {
-            var contents = fs.readFileSync("tslint/" + inputFileOrScript, 'utf8');
+            var contents = fs.readFileSync(inputFileOrScript, 'utf8');
             linter = new Lint.Linter(inputFileOrScript, contents, options);
         } else {
             linter = new Lint.Linter('file.ts', inputFileOrScript, options);


### PR DESCRIPTION
Now these can be tested as well! All existing tests still pass, and the no-http-string tests file now has 2 new tests to ensure that the optional parameters for this rule work as expected.