### PR TITLE
Cleanup TestHelper.ts

### DIFF
--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -3,7 +3,6 @@
 /// <reference path="../typings/chai.d.ts" />
 
 import * as Lint from 'tslint/lib/lint';
-import Linter = require('tslint');
 import fs = require('fs');
 import chai = require('chai');
 
@@ -42,23 +41,23 @@ module TestHelper {
             configuration.rules[ruleName] = true;
         }
 
-        var options : Lint.ILinterOptions = {
+        const options : Lint.ILinterOptions = {
             formatter: 'json',
             configuration: configuration,
             rulesDirectory: 'dist/src/',
             formattersDirectory: 'customFormatters/'
         };
 
-        var linter : Linter;
-        if (inputFileOrScript.match(/.*\.ts/)) {
-            var contents = fs.readFileSync(inputFileOrScript, 'utf8');
-            linter = new Linter(inputFileOrScript, contents, options);
+		let result: Lint.LintResult;
+        if (inputFileOrScript.match(/.*\.ts$/)) {
+            const contents = fs.readFileSync(inputFileOrScript, "utf8");
+            const linter = new Lint.Linter(inputFileOrScript, contents, options);
+            result = linter.lint();
         } else {
-            linter = new Linter('file.ts', inputFileOrScript, options);
+            const linter = new Lint.Linter("file.ts", inputFileOrScript, options);
+            result = linter.lint();
         }
 		
-        var result : Lint.LintResult = linter.lint();
-
         const actualFailures: IExpectedFailure[] = JSON.parse(result.output);
 
         // All the information we need is line and character of start position. For JSON comparison

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -29,7 +29,8 @@ module TestHelper {
         };
     }
 
-    function runRuleAndEnforceAssertions(ruleName : string, userOptions: string[], inputFileOrScript : string, expectedFailures : IExpectedFailure[]) {
+    function runRuleAndEnforceAssertions(ruleName: string, userOptions: string[], inputFileOrScript: string,
+		expectedFailures: IExpectedFailure[]) {
 
         const configuration: IRuleConfiguration = {
             rules: {}
@@ -50,14 +51,14 @@ module TestHelper {
 
 		let result: Lint.LintResult;
         if (inputFileOrScript.match(/.*\.ts$/)) {
-            const contents = fs.readFileSync(inputFileOrScript, "utf8");
+            const contents = fs.readFileSync(inputFileOrScript, 'utf8');
             const linter = new Lint.Linter(inputFileOrScript, contents, options);
             result = linter.lint();
         } else {
-            const linter = new Lint.Linter("file.ts", inputFileOrScript, options);
+            const linter = new Lint.Linter('file.ts', inputFileOrScript, options);
             result = linter.lint();
         }
-		
+
         const actualFailures: IExpectedFailure[] = JSON.parse(result.output);
 
         // All the information we need is line and character of start position. For JSON comparison
@@ -91,13 +92,13 @@ module TestHelper {
     export function assertNoViolationWithOptions(ruleName: string, options: any[], inputFileOrScript: string) {
         runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, []);
     }
-    export function assertViolationsWithOptions(ruleName: string, options: any[], inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
+    export function assertViolationsWithOptions(ruleName: string, options: any[], inputFileOrScript: string,
+		expectedFailures: IExpectedFailure[]) {
         runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, expectedFailures);
     }
     export function assertViolations(ruleName: string, inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
         runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, expectedFailures);
     }
-	
 }
 
 export = TestHelper;

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -12,17 +12,17 @@ import chai = require('chai');
  */
 module TestHelper {
 
-    export interface FailurePosition {
+    export interface IFailurePosition {
         character: number;
         line: number;
         position?: number;
     }
-    export interface ExpectedFailure {
+    export interface IExpectedFailure {
         ruleName: string;
         name: string;
         failure: string;
-        endPosition?: FailurePosition;
-        startPosition: FailurePosition;
+        endPosition?: IFailurePosition;
+        startPosition: IFailurePosition;
     }
     export function assertNoViolation(ruleName : string, inputFileOrScript : string) {
         runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, []);
@@ -30,16 +30,14 @@ module TestHelper {
     export function assertNoViolationWithOptions(ruleName : string, options: any[], inputFileOrScript : string) {
         runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, []);
     }
-    export function assertViolationsWithOptions(ruleName : string, options: any[], inputFileOrScript : string,
-                                                expectedFailures : ExpectedFailure[]) {
+    export function assertViolationsWithOptions(ruleName: string, options: any[], inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
         runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, expectedFailures);
     }
-    export function assertViolations(ruleName : string, inputFileOrScript : string, expectedFailures : ExpectedFailure[]) {
+    export function assertViolations(ruleName: string, inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
         runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, expectedFailures);
     }
 
-    function runRuleAndEnforceAssertions(ruleName : string, userOptions: string[], inputFileOrScript : string,
-                                         expectedFailures : ExpectedFailure[]) {
+    function runRuleAndEnforceAssertions(ruleName : string, userOptions: string[], inputFileOrScript : string, expectedFailures : IExpectedFailure[]) {
 
         var configuration = {
             rules: {}
@@ -68,12 +66,12 @@ module TestHelper {
 
         var result : Lint.LintResult = linter.lint();
 
-        var actualFailures: ExpectedFailure[] = JSON.parse(result.output);
+        const actualFailures: IExpectedFailure[] = JSON.parse(result.output);
 
         // All the information we need is line and character of start position. For JSON comparison
         // to work, we will delete the information that we are not interested in from both actual and
         // expected failures.
-        actualFailures.forEach((actual: ExpectedFailure): void => {
+        actualFailures.forEach((actual: IExpectedFailure): void => {
             delete actual.startPosition.position;
             delete actual.endPosition;
             // Editors start counting lines and characters from 1, but tslint does it from 0.
@@ -81,7 +79,7 @@ module TestHelper {
             actual.startPosition.line = actual.startPosition.line + 1;
             actual.startPosition.character = actual.startPosition.character + 1;
         });
-        expectedFailures.forEach((expected: ExpectedFailure): void => {
+        expectedFailures.forEach((expected: IExpectedFailure): void => {
             delete expected.startPosition.position;
             delete expected.endPosition;
         });
@@ -89,7 +87,7 @@ module TestHelper {
         var errorMessage = 'Wrong # of failures: \n' + JSON.stringify(actualFailures, null, 2);
         chai.assert.equal(expectedFailures.length, actualFailures.length, errorMessage);
 
-        expectedFailures.forEach((expected : ExpectedFailure, index: number) : void => {
+        expectedFailures.forEach((expected: IExpectedFailure, index: number): void => {
             var actual = actualFailures[index];
             chai.assert.deepEqual(actual, expected);
         });

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -84,7 +84,7 @@ module TestHelper {
             delete expected.endPosition;
         });
 
-        var errorMessage = 'Wrong # of failures: \n' + JSON.stringify(actualFailures, null, 2);
+        const errorMessage = `Wrong # of failures: \n${JSON.stringify(actualFailures, null, 2)}`;
         chai.assert.equal(expectedFailures.length, actualFailures.length, errorMessage);
 
         expectedFailures.forEach((expected: IExpectedFailure, index: number): void => {

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -75,7 +75,7 @@ module TestHelper {
             delete actual.startPosition.position;
             delete actual.endPosition;
             // Editors start counting lines and characters from 1, but tslint does it from 0.
-            // To make thing easier to debug, aling to editor values.
+            // To make thing easier to debug, align to editor values.
             actual.startPosition.line = actual.startPosition.line + 1;
             actual.startPosition.character = actual.startPosition.character + 1;
         });

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -24,10 +24,15 @@ module TestHelper {
         endPosition?: IFailurePosition;
         startPosition: IFailurePosition;
     }
+    interface IRuleConfiguration {
+        rules: {
+            [key: string]: boolean | any[];
+        };
+    }
 
     function runRuleAndEnforceAssertions(ruleName : string, userOptions: string[], inputFileOrScript : string, expectedFailures : IExpectedFailure[]) {
 
-        var configuration = {
+        const configuration: IRuleConfiguration = {
             rules: {}
         };
         if (userOptions != null && userOptions.length > 0) {
@@ -51,7 +56,7 @@ module TestHelper {
         } else {
             linter = new Linter('file.ts', inputFileOrScript, options);
         }
-
+		
         var result : Lint.LintResult = linter.lint();
 
         const actualFailures: IExpectedFailure[] = JSON.parse(result.output);

--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -24,18 +24,6 @@ module TestHelper {
         endPosition?: IFailurePosition;
         startPosition: IFailurePosition;
     }
-    export function assertNoViolation(ruleName : string, inputFileOrScript : string) {
-        runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, []);
-    }
-    export function assertNoViolationWithOptions(ruleName : string, options: any[], inputFileOrScript : string) {
-        runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, []);
-    }
-    export function assertViolationsWithOptions(ruleName: string, options: any[], inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
-        runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, expectedFailures);
-    }
-    export function assertViolations(ruleName: string, inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
-        runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, expectedFailures);
-    }
 
     function runRuleAndEnforceAssertions(ruleName : string, userOptions: string[], inputFileOrScript : string, expectedFailures : IExpectedFailure[]) {
 
@@ -92,6 +80,20 @@ module TestHelper {
             chai.assert.deepEqual(actual, expected);
         });
     }
+
+	export function assertNoViolation(ruleName: string, inputFileOrScript: string) {
+        runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, []);
+    }
+    export function assertNoViolationWithOptions(ruleName: string, options: any[], inputFileOrScript: string) {
+        runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, []);
+    }
+    export function assertViolationsWithOptions(ruleName: string, options: any[], inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
+        runRuleAndEnforceAssertions(ruleName, options, inputFileOrScript, expectedFailures);
+    }
+    export function assertViolations(ruleName: string, inputFileOrScript: string, expectedFailures: IExpectedFailure[]) {
+        runRuleAndEnforceAssertions(ruleName, null, inputFileOrScript, expectedFailures);
+    }
+	
 }
 
 export = TestHelper;


### PR DESCRIPTION
I did this cleanup in small commits to help explain what I did and why.  Mostly this was based on recommendations made by Visual Studio 2015 & ReSharper.

The commit `a5f283c` is the most important one, since it was previously always causing compile issue for me in VS.  This fixes it so that it still works like before, it compiles in VS, and it's a little easier to read.