### PR TITLE
More helpful failure message for noob developers

### DIFF
--- a/src/noForInRule.ts
+++ b/src/noForInRule.ts
@@ -7,7 +7,10 @@ import {ErrorTolerantWalker} from './utils/ErrorTolerantWalker';
  * Implementation of the no-for-in rule.
  */
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = 'Do not use for in statements, use Object.keys instead: ';
+    public static FAILURE_STRING_FACTORY = (initializer: string, expression: string ) => {
+        //tslint:disable-next-line:max-line-length
+        return `Do not use the 'for in' statement: 'for (${initializer} in ${expression})'. If this is an object, use 'Object.keys' instead. If this is an array use a standard 'for' loop instead.`;
+    }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoForInRuleWalker(sourceFile, this.getOptions()));
@@ -19,7 +22,7 @@ class NoForInRuleWalker extends ErrorTolerantWalker {
         const initializer: string = node.initializer.getText();
         const expression: string = node.expression.getText();
 
-        const msg: string = Rule.FAILURE_STRING + 'for (' + initializer + ' in ' + expression + ')';
+        const msg: string = Rule.FAILURE_STRING_FACTORY(initializer, expression);
         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), msg));
     }
 }

--- a/tests/NoForInRuleTests.ts
+++ b/tests/NoForInRuleTests.ts
@@ -3,6 +3,7 @@
 
 /* tslint:disable:quotemark */
 /* tslint:disable:no-multiline-string */
+/* tslint:disable:max-line-length */
 
 import {TestHelper} from './TestHelper';
 
@@ -12,9 +13,19 @@ import {TestHelper} from './TestHelper';
 describe('noForInRule', () : void => {
     const ruleName : string = 'no-for-in';
 
-    it('should pass on regular for statement', () : void => {
+    it('should pass on a regular for statement', () : void => {
         const script : string = `
             for (var i = 0; i < 100; i++) {
+
+            }
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
+    it('should pass on a regular for-of statement', () : void => {
+        const script : string = `
+            for (const item of array) {
 
             }
         `;
@@ -31,7 +42,7 @@ describe('noForInRule', () : void => {
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                "failure": "Do not use for in statements, use Object.keys instead: for (name in object)",
+                "failure": "Do not use the 'for in' statement: 'for (name in object)'. If this is an object, use 'Object.keys' instead. If this is an array use a standard 'for' loop instead.",
                 "name": "file.ts",
                 "ruleName": "no-for-in",
                 "startPosition": { "character": 13, "line": 2 }
@@ -42,3 +53,4 @@ describe('noForInRule', () : void => {
 });
 /* tslint:enable:quotemark */
 /* tslint:enable:no-multiline-string */
+/* tslint:enable:max-line-length */


### PR DESCRIPTION
I've run into a situation at work where a less-experienced developer was trying to use a `for in` statement to loop over a standard array of strings, like so:

```typescript
const arr = ["foo", "bar", "baz"];
for (item in arr) {
  //do stuff
}
```

Then TSLint would produce the message:
> Do not use for in statements, use Object.keys instead: for (item in arr)

So the developer said "OK" and then went and changed the code to this:
```typescript
const arr = ["foo", "bar", "baz"];
Object.keys(arr).forEach((key: number) => {
  //do stuff
});
```

:neutral_face: 

Sooo... *technically* both ways actually do work for looping over flat arrays, but obviously they are not ideal.  I wanted to make the failure message for this rule a bit more explicit to better describe the available options.  Now the rule will produce this failure message:

>Do not use the 'for in' statement: 'for (item in arr)'. If this is an object, use 'Object.keys' instead. If this is an array use a standard 'for' loop instead.