### PR TITLE
Trim whitespace from message in `no-multiline-strings`

### DIFF
--- a/src/noMultilineStringRule.ts
+++ b/src/noMultilineStringRule.ts
@@ -20,7 +20,7 @@ class NoMultilineStringWalker extends ErrorTolerantWalker {
         if (node.kind === SyntaxKind.current().NoSubstitutionTemplateLiteral) {
             const fullText : string = node.getFullText();
             const firstLine : string = fullText.substring(0, fullText.indexOf('\n'));
-            const trimmed : string = firstLine.substring(0, 40);
+            const trimmed : string = firstLine.substring(0, 40).trim();
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING + trimmed + '...'));
         }
         super.visitNode(node);

--- a/tests/NoMultilineStringTests.ts
+++ b/tests/NoMultilineStringTests.ts
@@ -14,7 +14,7 @@ describe('noMultilineStringRule', () : void => {
         const inputFile : string = 'test-data/NoMultilineStringTestInput.ts';
         TestHelper.assertViolations(RULE_NAME, inputFile, [
             {
-                "failure": "Forbidden Multiline string:  `some...",
+                "failure": "Forbidden Multiline string: `some...",
                 "name": "test-data/NoMultilineStringTestInput.ts",
                 "ruleName": "no-multiline-string",
                 "startPosition": {


### PR DESCRIPTION
on master, I keep running into this test failure with the `no-multiline-strings` rule when I run the tests locally.  It happened a long time ago to me and I ignored it as a fluke, but it's still happening to me today.

![image](https://cloud.githubusercontent.com/assets/463685/16266659/04c0a008-3854-11e6-868c-822ff47b5d75.png)

Basically it seems to expect the line break inside the reported string for the error message.  This was an easy thing to fix though, and now all tests pass for me with this small change.