### PR TITLE
Fix trailing comma rule

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -128,7 +128,7 @@ module.exports = {
         "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
         "quotemark": [true, "single"],
         "semicolon": [true, "always"],
-        "trailing-comma": true,
+        "trailing-comma": [true, {"singleline": "never", "multiline": "always"}],
         "typedef-whitespace": false,
         "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
 

--- a/src/utils/SyntaxKind.ts
+++ b/src/utils/SyntaxKind.ts
@@ -1172,7 +1172,7 @@ export module SyntaxKind {
         LastTemplateToken: 14,
         FirstBinaryOperator: 25,
         LastBinaryOperator: 68,
-        FirstNode: 135,
+        FirstNode: 135
     };
 
     /* tslint:disable:variable-name */

--- a/tslint.json
+++ b/tslint.json
@@ -112,7 +112,7 @@
     "react-this-binding-issue": true,
     "semicolon": true,
     "switch-default": false,
-    "trailing-comma": true,
+    "trailing-comma": [true, {"singleline": "never", "multiline": "never"}],
     "triple-equals": [true, "allow-null-check"],
     "typedef": [true, "callSignature", "indexSignature", "parameter", "propertySignature", "variableDeclarator", "memberVariableDeclarator"],
     "typedef-whitespace": false,


### PR DESCRIPTION
`recommended_ruleset.js` contains the following rule:

```js
"trailing-comma": true,
```

This is actually a no-op because you should set `multiline` and `singleline` options in order to enable corresponding checks (see [trailing-comma rule doc](http://palantir.github.io/tslint/rules/trailing-comma/) and [recommended.ts](https://github.com/palantir/tslint/blob/master/src/configs/recommended.ts#L91)):

```js
"trailing-comma": [true, {"singleline": "never", "multiline": "always"}],
```

The rationale behind enforcing trailing commas for multiline statements is covered by [this article](https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8).

Hovewer, the established code style in `tslint-microsoft-contrib` assumes that trailing commas are disallowed so I've decided to set `"multiline": "never"` in `tslint.json` as a compromise and fix one redundant trailing comma.