### PR TITLE
React a11y titles - issue #197

### DIFF
--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -6,8 +6,8 @@ import {ExtendedMetadata} from './utils/ExtendedMetadata';
 import {Utils} from './utils/Utils';
 
 const EMPTY_TITLE_FAILURE_STRING: string = 'Title elements must not be empty';
-const LONG_TITLE_FAILURE_STRING: string = "Title length must not be longer than 60 characters";
-const WORD_TITLE_FAILURE_STRING: string = "Title must contain more than one word";
+const LONG_TITLE_FAILURE_STRING: string = 'Title length must not be longer than 60 characters';
+const WORD_TITLE_FAILURE_STRING: string = 'Title must contain more than one word';
 const MAX_TITLE_LENGTH: number = 60;
 
 /**
@@ -54,10 +54,10 @@ class ReactA11yTitlesRuleWalker extends ErrorTolerantWalker {
                     const text: string = value.getText();
                     if (text.length > MAX_TITLE_LENGTH) {
                        this.addFailure(this.createFailure(node.getStart(),
-                       node.getWidth(), LONG_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)))
-                    } else if (text.indexOf(' ') < 2) {
+                       node.getWidth(), LONG_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)));
+                    } else if (!(text.indexOf(' ') > 0)) {
                         this.addFailure(this.createFailure(node.getStart(),
-                        node.getWidth(), WORD_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)))
+                        node.getWidth(), WORD_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)));
                     }
                 }
             }

--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -3,8 +3,11 @@ import * as Lint from 'tslint/lib/lint';
 
 import {ErrorTolerantWalker} from './utils/ErrorTolerantWalker';
 import {ExtendedMetadata} from './utils/ExtendedMetadata';
+import {Utils} from './utils/Utils';
 
-const FAILURE_STRING: string = 'Title elements must not be empty';
+const EMPTY_TITLE_FAILURE_STRING: string = 'Title elements must not be empty';
+const LONG_TITLE_FAILURE_STRING: string = "Title length must not be longer than 60 characters";
+const MAX_TITLE_LENGTH: number = 60;
 
 /**
  * Implementation of the react-a11y-titles rule.
@@ -14,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: ExtendedMetadata = {
         ruleName: 'react-a11y-titles',
         type: 'functionality',
-        description: 'For accessibility of your website, HTML title elements must not be empty.',
+        description: 'For accessibility of your website, HTML x1title elements must not be empty.',
         options: null,
         issueClass: 'Ignored',
         issueType: 'Warning',
@@ -33,7 +36,7 @@ class ReactA11yTitlesRuleWalker extends ErrorTolerantWalker {
     protected visitJsxSelfClosingElement(node: ts.JsxSelfClosingElement): void {
         if (node.tagName.getText() === 'title') {
             this.addFailure(this.createFailure(node.getStart(),
-                node.getWidth(), FAILURE_STRING));
+                node.getWidth(), EMPTY_TITLE_FAILURE_STRING));
         }
         super.visitJsxSelfClosingElement(node);
     }
@@ -43,9 +46,19 @@ class ReactA11yTitlesRuleWalker extends ErrorTolerantWalker {
         if (openingElement.tagName.getText() === 'title') {
             if (node.children.length === 0) {
                 this.addFailure(this.createFailure(node.getStart(),
-                    node.getWidth(), FAILURE_STRING));
+                    node.getWidth(), EMPTY_TITLE_FAILURE_STRING));
+            } else if (node.children.length === 1) {
+                if (node.children[0].kind === ts.SyntaxKind.JsxText) {
+                    const value: ts.JsxText = <ts.JsxText>node.children[0];
+                    const text: string = value.getText();
+                    if (text.length <= MAX_TITLE_LENGTH) {
+                       this.addFailure(this.createFailure(node.getStart(),
+                       node.getWidth(), LONG_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)))
+                    }
+                }
             }
         }
         super.visitJsxElement(node);
     }
+
 }

--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -7,6 +7,7 @@ import {Utils} from './utils/Utils';
 
 const EMPTY_TITLE_FAILURE_STRING: string = 'Title elements must not be empty';
 const LONG_TITLE_FAILURE_STRING: string = "Title length must not be longer than 60 characters";
+const WORD_TITLE_FAILURE_STRING: string = "Title must contain more than one word";
 const MAX_TITLE_LENGTH: number = 60;
 
 /**
@@ -51,9 +52,12 @@ class ReactA11yTitlesRuleWalker extends ErrorTolerantWalker {
                 if (node.children[0].kind === ts.SyntaxKind.JsxText) {
                     const value: ts.JsxText = <ts.JsxText>node.children[0];
                     const text: string = value.getText();
-                    if (text.length <= MAX_TITLE_LENGTH) {
+                    if (text.length > MAX_TITLE_LENGTH) {
                        this.addFailure(this.createFailure(node.getStart(),
                        node.getWidth(), LONG_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)))
+                    } else if (text.indexOf(' ') < 2) {
+                        this.addFailure(this.createFailure(node.getStart(),
+                        node.getWidth(), WORD_TITLE_FAILURE_STRING + ': ' + Utils.trimTo(text, 20)))
                     }
                 }
             }

--- a/tests/ReactA11yTitlesRuleTests.ts
+++ b/tests/ReactA11yTitlesRuleTests.ts
@@ -55,7 +55,7 @@ describe('reactA11yTitlesRule', () : void => {
     });
 
     it('should fail on longer than 60 charactes title', () : void => {
-        let title: string = Array(61).join("a")
+        const title: string = Array(61).join("a");
         const script : string = `
             import React = require('react');
 
@@ -76,7 +76,7 @@ describe('reactA11yTitlesRule', () : void => {
     });
 
     it('should pass on shorter than 60 charactes title', () : void => {
-        let title: string = Array(5).join("a")
+        const title: string = Array(5).join("a");
         const script : string = `
             import React = require('react');
 

--- a/tests/ReactA11yTitlesRuleTests.ts
+++ b/tests/ReactA11yTitlesRuleTests.ts
@@ -54,21 +54,62 @@ describe('reactA11yTitlesRule', () : void => {
         ]);
     });
 
-    it.only('should fail on longer than 60 charactes title', () : void => {
+    it('should fail on longer than 60 charactes title', () : void => {
         let title: string = Array(61).join("a")
         const script : string = `
             import React = require('react');
 
-            const title = <title>${title}</title>;
+            const title = <title>test ${title}</title>;
         `;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                "failure": "Title length must not be longer than 60 characters: aaaaaaaaaaaaaaaaaa...",
+                "failure": "Title length must not be longer than 60 characters: test aaaaaaaaaaaaa...",
                 "name": "file.tsx",
                 "ruleName": "react-a11y-titles",
-                "startPosition": { "character": 27, "line": 4 }
+                "startPosition": {
+                    "character": 27,
+                    "line": 4
+                }
             }
         ]);
     });
+
+    it('should pass on shorter than 60 charactes title', () : void => {
+        let title: string = Array(5).join("a")
+        const script : string = `
+            import React = require('react');
+
+            const title = <title>test ${title}</title>;
+        `;
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
+    it('should fail on single world title', () : void => {
+        const script : string = `
+            import React = require('react');
+
+            const title = <title>test</title>;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [
+            {
+                "failure": "Title must contain more than one word: test",
+                "name": "file.tsx",
+                "ruleName": "react-a11y-titles",
+                "startPosition": {"character": 27, "line": 4
+                }
+            }
+        ]);
+    });
+
+    it('should pass on multi world title', () : void => {
+        const script : string = `
+            import React = require('react');
+
+            const title = <title>test test</title>;
+        `;
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
 });

--- a/tests/ReactA11yTitlesRuleTests.ts
+++ b/tests/ReactA11yTitlesRuleTests.ts
@@ -53,4 +53,22 @@ describe('reactA11yTitlesRule', () : void => {
             }
         ]);
     });
+
+    it.only('should fail on longer than 60 charactes title', () : void => {
+        let title: string = Array(61).join("a")
+        const script : string = `
+            import React = require('react');
+
+            const title = <title>${title}</title>;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [
+            {
+                "failure": "Title length must not be longer than 60 characters: aaaaaaaaaaaaaaaaaa...",
+                "name": "file.tsx",
+                "ruleName": "react-a11y-titles",
+                "startPosition": { "character": 27, "line": 4 }
+            }
+        ]);
+    });
 });


### PR DESCRIPTION
Completed the react a11y title rule:
 - Title content should be less than 60 characters 
 - Title text must contain more than one word