### PR TITLE
Fix - TestHelper: "Wrong # of failures" actual vs expected

### DIFF
--- a/tests/TestHelper.ts
+++ b/tests/TestHelper.ts
@@ -121,7 +121,7 @@ export module TestHelper {
         });
 
         const errorMessage = `Wrong # of failures: \n${JSON.stringify(actualFailures, null, 2)}`;
-        chai.assert.equal(expectedFailures.length, actualFailures.length, errorMessage);
+        chai.assert.equal(actualFailures.length, expectedFailures.length, errorMessage);
 
         expectedFailures.forEach((expected: ExpectedFailure, index: number): void => {
             const actual = actualFailures[index];


### PR DESCRIPTION
chai.assert.equal(actual, expected, [message])
http://chaijs.com/api/assert/