### PR TITLE
Will allow us to use `extends` in our tslint.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/tslint-microsoft-contrib/issues"
   },
-  "main": "package.json",
+  "main": "tslint.json",
   "keywords": [
     "tslint",
     "microsoft",


### PR DESCRIPTION
This will allow us to use 

```js
"extends": "tslint-microsoft-contrib"
```
in our project's `tslint.json`.