### PR TITLE
fix to make img element allow role='presentation' with non-empty alt

### DIFF
--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -15,7 +15,7 @@ const ALT_STRING: string = 'alt';
 
 export function getFailureStringNoAlt(tagName: string): string {
     return `<${tagName}> elements must have an non-empty alt attribute or \
-use empty alt attribute and role='presentation' for presentational images. \
+use empty alt attribute as well as role='presentation' for decorative/presentational images. \
 A reference for the presentation role can be found at https://www.w3.org/TR/wai-aria/roles#presentation.`;
 }
 
@@ -100,8 +100,12 @@ class ImgHasAltWalker extends Lint.RuleWalker {
             const roleAttributeValue: string = roleAttribute ? getStringLiteral(roleAttribute) : '';
             const isPresentationRole: boolean = !!roleAttributeValue.toLowerCase().match(/\bpresentation\b/);
             const isEmptyAlt: boolean = isEmpty(altAttribute) || getStringLiteral(altAttribute) === '';
+            const allowNonEmptyAltWithRolePresentation: boolean = options.length > 2
+                ? options[2].allowNonEmptyAltWithRolePresentation
+                : false;
 
-            if (!isEmptyAlt && isPresentationRole) { // <img alt='altValue' role='presentation' />
+            // <img alt='altValue' role='presentation' />
+            if (!isEmptyAlt && isPresentationRole && !allowNonEmptyAltWithRolePresentation) {
                 this.addFailure(this.createFailure(
                     node.getStart(),
                     node.getWidth(),

--- a/src/tests/reactA11yImgHasAltRuleTests.ts
+++ b/src/tests/reactA11yImgHasAltRuleTests.ts
@@ -39,6 +39,12 @@ describe('reactA11yImgHasAlt', () => {
         const fileName: string = fileDirectory + 'ImgElementHasNonEmptyAltValueAndNotPresentationRole.tsx';
         TestHelper.assertNoViolation(ruleName, fileName);
       });
+
+      it('when the img element has non-empty alt value and presentation role when option is enabled', () => {
+        const fileName: string = fileDirectory + 'ImgElementHasNonEmptyAltValueAndPresentationRole.tsx';
+        const ruleOptions: any[] = [true, [], { allowNonEmptyAltWithRolePresentation: true }];
+        TestHelper.assertNoViolationWithOptions(ruleName, ruleOptions, fileName);
+      });
     });
 
     describe('should fail', () => {

--- a/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementHasNonEmptyAltValueAndPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementHasNonEmptyAltValueAndPresentationRole.tsx
@@ -1,0 +1,8 @@
+import React = require('react');
+
+let altValue;
+
+const a = <img alt='altValue' role='presentation' />
+const b = <img Alt='altValue' role='presentation button' />
+const c = <img ALT={ altValue } role={ 'presentation' } />
+const d = <img alt={'altValue'} role='Presentation' />


### PR DESCRIPTION
 - consumers can now specify this options to declare whether there project supports Non-empty alt text with role equals presentation.
 - add one test case for the enabled option.
 - closes #298