### PR TITLE
Remove deprecated no-duplicate-key rule

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -324,7 +324,8 @@ module.exports = function(grunt) {
             'no-unexternalized-strings': true,
             'object-literal-key-quotes': true,
             'no-relative-imports': true,
-            'no-empty-line-after-opening-brace': true
+            'no-empty-line-after-opening-brace': true,
+            'no-duplicate-key': true
         };
         var errors = [];
         getAllRuleNames().forEach(function(ruleName) {

--- a/additional_rule_metadata.json
+++ b/additional_rule_metadata.json
@@ -245,14 +245,6 @@
     "group": "Clarity",
     "commonWeaknessEnumeration": "710"
   },
-  "no-duplicate-key": {
-    "issueClass": "SDL",
-    "issueType": "Error",
-    "severity": "Critical",
-    "level": "Mandatory",
-    "group": "Security",
-    "commonWeaknessEnumeration": "398, 694, 462"
-  },
   "no-duplicate-variable": {
     "issueClass": "Non-SDL",
     "issueType": "Error",

--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -16,7 +16,6 @@ module.exports = {
         "no-disable-auto-sanitization": true,
         "no-document-domain": true,
         "no-document-write": true,
-        "no-duplicate-key": true,
         "no-eval": true,
         "no-exec-script": true,
         "no-function-constructor-with-string-args": true,

--- a/tslint-warnings.csv
+++ b/tslint-warnings.csv
@@ -83,9 +83,7 @@ no-document-write,Do not use document.write,TSLINTMGIOVQ,tslint,SDL,Error,Critic
 CWE 85 - Doubled Character XSS Manipulations"
 no-duplicate-case,Do not use duplicate case labels in switch statements.,TSLINT3MSPFV,tslint,Non-SDL,Error,Critical,Opportunity for Excellence,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,"398, 710","CWE 398 - Indicator of Poor Code Quality
 CWE 710 - Coding Standards Violation"
-no-duplicate-key,Disallows duplicate keys in object literals.,TSLINT8C37DG,tslint,SDL,Error,Critical,Mandatory,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,"398, 694, 462","CWE 398 - Indicator of Poor Code Quality
-CWE 694 - Use of Multiple Resources with Duplicate Identifier
-CWE 462 - Duplicate Key in Associative List (Alist)"
+no-duplicate-key,Disallows duplicate keys in object literals.,TSLINT8C37DG,tslint,,,,,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,,
 no-duplicate-variable,Disallows duplicate variable declarations in the same block scope.,TSLINT6TMGHL,tslint,Non-SDL,Error,Critical,Opportunity for Excellence,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,398,"CWE 398 - Indicator of Poor Code Quality"
 no-empty,Disallows empty blocks.,TSLINTJ99V50,tslint,Non-SDL,Warning,Moderate,Opportunity for Excellence,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,398,"CWE 398 - Indicator of Poor Code Quality"
 no-empty-interfaces,Do not use empty interfaces.,TSLINT1L2THN7,tslint,Non-SDL,Warning,Moderate,Opportunity for Excellence,See description on the tslint or tslint-microsoft-contrib website,TSLint Procedure,"398, 710","CWE 398 - Indicator of Poor Code Quality

--- a/tslint.json
+++ b/tslint.json
@@ -82,7 +82,6 @@
     "no-document-domain": true,
     "no-document-write": true,
     "no-duplicate-case": true,
-    "no-duplicate-key": true,
     "no-duplicate-parameter-names": true,
     "no-duplicate-variable": true,
     "no-empty": true,


### PR DESCRIPTION
This has been deprecated in tslint's upcoming 4.x (https://github.com/palantir/tslint/issues/885) as it's functionality which is covered by the compiler. For that reason, removing the rule prior to release should have no negative effects and is one less thing to change down the line 😄 