### PR TITLE
Declare TypeScript SDK path in VSCode settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
 {
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
+    "typescript.tsdk": "./node_modules/typescript/lib",
     "files.trimTrailingWhitespace": true
 }


### PR DESCRIPTION
As of VSCode 1.6.0, it use 2.x as default. This project still uses 1.8. If not declare the path explicitly, VSCode will prompt to choose version every time.