### PR TITLE
mocha-no-side-effect: Add support for "BeforeAll()" and "afterAll()" methods (Jasmine)

### DIFF
--- a/src/mochaNoSideEffectCodeRule.ts
+++ b/src/mochaNoSideEffectCodeRule.ts
@@ -98,8 +98,8 @@ class MochaNoSideEffectCodeRuleWalker extends ErrorTolerantWalker {
                 this.isInDescribe = false;
             }
         } else if (functionName === 'it'
-                || functionName === 'before' || functionName === 'beforeEach'
-                || functionName === 'after' || functionName === 'afterEach') {
+                || functionName === 'before' || functionName === 'beforeEach' || functionName === 'beforeAll'
+                || functionName === 'after' || functionName === 'afterEach' || functionName === 'afterAll') {
             // variable initialization is allowed inside the lifecycle methods, so do not visit them
             return;
         } else if (this.isInDescribe) {

--- a/src/tests/MochaNoSideEffectCodeRuleTests.ts
+++ b/src/tests/MochaNoSideEffectCodeRuleTests.ts
@@ -29,10 +29,16 @@ describe('mochaNoSideEffectCodeRule', () : void => {
                 beforeEach((): void => {
                     const foo = someValue();
                 });
+                beforeAll((): void => {
+                    const foo = someValue();
+                });
                 after((): void => {
                     const foo = someValue();
                 });
                 afterEach((): void => {
+                    const foo = someValue();
+                });
+                afterAll((): void => {
                     const foo = someValue();
                 });
                 it((): void => {
@@ -148,10 +154,16 @@ describe('mochaNoSideEffectCodeRule', () : void => {
                 beforeEach((): void => {
                     const foo = someValue();
                 });
+                beforeAll((): void => {
+                    const foo = someValue();
+                });
                 after((): void => {
                     const foo = someValue();
                 });
                 afterEach((): void => {
+                    const foo = someValue();
+                });
+                afterAll((): void => {
                     const foo = someValue();
                 });
                 it((): void => {


### PR DESCRIPTION
This PR simply adds support for the `beforeAll` and `afterAll` methods that are used in Jasmine to the mocha-no-side-effect rule. 

If you're not familiar, `beforeAll` and `afterAll` are equivalent to mocha's `before` and `after`.

I've updated the test as well.

Let me know if you'd like me to do anything else. Thanks so much 😄 