### PR TITLE
function-name rule - add support for linting protected methods

### DIFF
--- a/src/functionNameRule.ts
+++ b/src/functionNameRule.ts
@@ -36,7 +36,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class FunctionNameRuleWalker extends ErrorTolerantWalker {
 
     private methodRegex: RegExp = /^[a-z][\w\d]+$/;
-    private privateMethodRegex: RegExp = /^[a-z][\w\d]+$/;
+    private privateMethodRegex: RegExp = this.methodRegex;
     private staticMethodRegex: RegExp = /^[A-Z_\d]+$/;
     private functionRegex: RegExp = /^[a-z][\w\d]+$/;
 

--- a/src/functionNameRule.ts
+++ b/src/functionNameRule.ts
@@ -7,6 +7,7 @@ import {ExtendedMetadata} from './utils/ExtendedMetadata';
 
 const METHOD_REGEX = 'method-regex';
 const PRIVATE_METHOD_REGEX = 'private-method-regex';
+const PROTECTED_METHOD_REGEX = 'protected-method-regex';
 const STATIC_METHOD_REGEX = 'static-method-regex';
 const FUNCTION_REGEX = 'function-regex';
 
@@ -37,6 +38,7 @@ class FunctionNameRuleWalker extends ErrorTolerantWalker {
 
     private methodRegex: RegExp = /^[a-z][\w\d]+$/;
     private privateMethodRegex: RegExp = this.methodRegex;
+    private protectedMethodRegex: RegExp = this.privateMethodRegex;
     private staticMethodRegex: RegExp = /^[A-Z_\d]+$/;
     private functionRegex: RegExp = /^[a-z][\w\d]+$/;
 
@@ -46,6 +48,7 @@ class FunctionNameRuleWalker extends ErrorTolerantWalker {
             if (typeof(opt) === 'object') {
                 this.methodRegex = this.getOptionOrDefault(opt, METHOD_REGEX, this.methodRegex);
                 this.privateMethodRegex = this.getOptionOrDefault(opt, PRIVATE_METHOD_REGEX, this.privateMethodRegex);
+                this.protectedMethodRegex = this.getOptionOrDefault(opt, PROTECTED_METHOD_REGEX, this.protectedMethodRegex);
                 this.staticMethodRegex = this.getOptionOrDefault(opt, STATIC_METHOD_REGEX, this.staticMethodRegex);
                 this.functionRegex = this.getOptionOrDefault(opt, FUNCTION_REGEX, this.functionRegex);
             }
@@ -58,6 +61,11 @@ class FunctionNameRuleWalker extends ErrorTolerantWalker {
             if (!this.privateMethodRegex.test(name)) {
                 this.addFailure(this.createFailure(node.name.getStart(), node.name.getWidth(),
                     `Private method name does not match ${this.privateMethodRegex}: ${name}`));
+            }
+        } else if (AstUtils.isProtected(node)) {
+            if (!this.protectedMethodRegex.test(name)) {
+                this.addFailure(this.createFailure(node.name.getStart(), node.name.getWidth(),
+                    `Protected method name does not match ${this.protectedMethodRegex}: ${name}`));
             }
         } else if (AstUtils.isStatic(node)) {
             if (!this.staticMethodRegex.test(name)) {

--- a/src/tests/FunctionNameRuleTests.ts
+++ b/src/tests/FunctionNameRuleTests.ts
@@ -52,6 +52,19 @@ describe('functionNameRule', () : void => {
         TestHelper.assertViolations(ruleName, script, [ ]);
     });
 
+    it('should pass on correctly protected static methods', () : void => {
+        const script : string = `
+            class MyClass {
+                protected static bar() {}
+                protected static bar1() {}
+                protected static myBar() {}
+                protected static myBar1() {}
+            }
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
     it('should fail on incorrect public methods', () : void => {
         const script : string = `
             class MyClass {
@@ -138,6 +151,51 @@ describe('functionNameRule', () : void => {
                 "name": "file.ts",
                 "ruleName": "function-name",
                 "startPosition": { "character": 25, "line": 7 }
+            }
+        ]);
+    });
+
+    it('should fail on incorrect protected methods', () : void => {
+        const script : string = `
+            class MyClass {
+                protected Foo() {}
+                protected _foo() {}
+                protected FOO() {}
+                protected _FOO() {}
+                protected _foo() {}
+            }
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [
+            {
+                "failure": "Protected method name does not match /^[a-z][\\w\\d]+$/: Foo",
+                "name": "file.ts",
+                "ruleName": "function-name",
+                "startPosition": { "character": 27, "line": 3 }
+            },
+            {
+                "failure": "Protected method name does not match /^[a-z][\\w\\d]+$/: _foo",
+                "name": "file.ts",
+                "ruleName": "function-name",
+                "startPosition": { "character": 27, "line": 4 }
+            },
+            {
+                "failure": "Protected method name does not match /^[a-z][\\w\\d]+$/: FOO",
+                "name": "file.ts",
+                "ruleName": "function-name",
+                "startPosition": { "character": 27, "line": 5 }
+            },
+            {
+                "failure": "Protected method name does not match /^[a-z][\\w\\d]+$/: _FOO",
+                "name": "file.ts",
+                "ruleName": "function-name",
+                "startPosition": { "character": 27, "line": 6 }
+            },
+            {
+                "failure": "Protected method name does not match /^[a-z][\\w\\d]+$/: _foo",
+                "name": "file.ts",
+                "ruleName": "function-name",
+                "startPosition": { "character": 27, "line": 7 }
             }
         ]);
     });


### PR DESCRIPTION
this adds support for `protected` class methods on classes for the `function-name` rule.

also, removed the duplicate regexp across public, private & protected methods.