### PR TITLE
Support for Typescript 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "2.2.5",
     "time-grunt": "1.2.1",
     "tslint": "3.14.0",
-    "typescript": "2.0.6",
+    "typescript": "2.1.1",
     "underscore": "1.8.3"
   }
 }

--- a/src/fixNoRequireImportsFormatter.ts
+++ b/src/fixNoRequireImportsFormatter.ts
@@ -11,7 +11,7 @@ export class Formatter extends BaseFormatter {
 /* tslint:enable:export-name */
 
     constructor() {
-        super('no-require-imports', (failure: RuleFailure): void => {
+        super('no-require-imports', function (this: Formatter, failure: RuleFailure): void {
             const fileName: string = failure.getFileName();
             const fileContents: string = this.readFile(fileName);
             const start: number = failure.getStartPosition().getPosition();

--- a/src/fixNoUnusedImportsFormatter.ts
+++ b/src/fixNoUnusedImportsFormatter.ts
@@ -11,7 +11,7 @@ export class Formatter extends BaseFormatter {
 /* tslint:enable:export-name */
 
     constructor() {
-        super('no-unused-imports', (failure: RuleFailure): void => {
+        super('no-unused-imports', function (this: Formatter, failure: RuleFailure): void {
             const fileName: string = failure.getFileName();
             const start: RuleFailurePosition = failure.getStartPosition();
             const end: RuleFailurePosition = failure.getEndPosition();

--- a/src/fixNoVarKeywordFormatter.ts
+++ b/src/fixNoVarKeywordFormatter.ts
@@ -11,8 +11,7 @@ export class Formatter extends BaseFormatter {
 /* tslint:enable:export-name */
 
     constructor() {
-        super('no-var-keyword', (failure: RuleFailure): void => {
-
+        super('no-var-keyword', function (this: Formatter, failure: RuleFailure): void {
             const fileName: string = failure.getFileName();
             const fileContents: string = this.readFile(fileName);
             const end: number = failure.getEndPosition().getPosition();

--- a/src/fixPreferConstFormatter.ts
+++ b/src/fixPreferConstFormatter.ts
@@ -11,7 +11,7 @@ export class Formatter extends BaseFormatter {
 /* tslint:enable:export-name */
 
     constructor() {
-        super('prefer-const', (failure: RuleFailure): void => {
+        super('prefer-const', function (this: Formatter, failure: RuleFailure): void {
             const fileName: string = failure.getFileName();
             const fileContents: string = this.readFile(fileName);
             const start: number = failure.getStartPosition().getPosition();

--- a/src/noControlRegexRule.ts
+++ b/src/noControlRegexRule.ts
@@ -49,7 +49,7 @@ class NoControlRegexRuleWalker extends ErrorTolerantWalker {
     }
 
     /* tslint:disable:no-control-regex */
-    private validateCall(expression: ts.CallExpression): void {
+    private validateCall(expression: ts.CallExpression | ts.NewExpression): void {
         if (expression.expression.getText() === 'RegExp') {
             if (expression.arguments.length > 0) {
                 const arg1: ts.Expression = expression.arguments[0];

--- a/src/noIncrementDecrementRule.ts
+++ b/src/noIncrementDecrementRule.ts
@@ -39,7 +39,7 @@ class NoIncrementDecrementWalker extends ErrorTolerantWalker {
         super.visitPrefixUnaryExpression(node);
     }
 
-    private validateUnaryExpression(node : ts.PrefixUnaryExpression | ts.PrefixUnaryExpression) {
+    private validateUnaryExpression(node : ts.PrefixUnaryExpression | ts.PostfixUnaryExpression) {
         if (node.operator === SyntaxKind.current().PlusPlusToken) {
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), 'Forbidden ++ operator'));
         } else if (node.operator === SyntaxKind.current().MinusMinusToken) {

--- a/src/noInvalidRegexpRule.ts
+++ b/src/noInvalidRegexpRule.ts
@@ -38,7 +38,7 @@ class NoInvalidRegexpRuleWalker extends ErrorTolerantWalker {
         super.visitCallExpression(node);
     }
 
-    private validateCall(expression: ts.CallExpression): void {
+    private validateCall(expression: ts.CallExpression | ts.NewExpression): void {
         if (expression.expression.getText() === 'RegExp') {
             if (expression.arguments.length > 0) {
                 const arg1: ts.Expression = expression.arguments[0];

--- a/src/preferConstRule.ts
+++ b/src/preferConstRule.ts
@@ -90,9 +90,9 @@ class PreferConstWalker extends ErrorTolerantWalker {
         this.popDeclarations();
     }
 
-    public visitBlock(node: ts.Block) {
+    public visitBlock(node: ts.Block | ts.ModuleBlock) {
         this.visitAnyStatementList(node.statements);
-        super.visitBlock(node);
+        super.visitBlock(<ts.Block>node);
         this.popDeclarations();
     }
 

--- a/src/preferConstRule.ts
+++ b/src/preferConstRule.ts
@@ -180,7 +180,9 @@ class PreferConstWalker extends ErrorTolerantWalker {
 
     private visitBindingPatternIdentifiers(pattern: ts.BindingPattern): void {
         pattern.elements.forEach((element): void => {
-            if (element.name.kind === SyntaxKind.current().Identifier) {
+            if (element.kind === SyntaxKind.current().OmittedExpression) {
+                return
+            } else if (element.name.kind === SyntaxKind.current().Identifier) {
                 this.markAssignment(<ts.Identifier>element.name);
             } else {
                 this.visitBindingPatternIdentifiers(<ts.BindingPattern>element.name);

--- a/src/preferConstRule.ts
+++ b/src/preferConstRule.ts
@@ -181,7 +181,7 @@ class PreferConstWalker extends ErrorTolerantWalker {
     private visitBindingPatternIdentifiers(pattern: ts.BindingPattern): void {
         pattern.elements.forEach((element): void => {
             if (element.kind === SyntaxKind.current().OmittedExpression) {
-                return
+                return;
             } else if (element.name.kind === SyntaxKind.current().Identifier) {
                 this.markAssignment(<ts.Identifier>element.name);
             } else {
@@ -218,7 +218,7 @@ class PreferConstWalker extends ErrorTolerantWalker {
                                              table: ts.Map<IDeclarationUsages>): void {
         pattern.elements.forEach((element): void => {
             if (element.kind === SyntaxKind.current().OmittedExpression) {
-                return
+                return;
             }
             this.collectNameIdentifiers(value, element.name, table);
         });

--- a/src/preferConstRule.ts
+++ b/src/preferConstRule.ts
@@ -217,6 +217,9 @@ class PreferConstWalker extends ErrorTolerantWalker {
                                              pattern: ts.BindingPattern,
                                              table: ts.Map<IDeclarationUsages>): void {
         pattern.elements.forEach((element): void => {
+            if (element.kind === SyntaxKind.current().OmittedExpression) {
+                return
+            }
             this.collectNameIdentifiers(value, element.name, table);
         });
     }

--- a/src/reactA11yAnchorsRule.ts
+++ b/src/reactA11yAnchorsRule.ts
@@ -111,7 +111,7 @@ class ReactA11yAnchorsRuleWalker extends ErrorTolerantWalker {
         super.visitJsxElement(node);
     }
 
-    private validateAnchor(parent: ts.Node, openingElement: ts.JsxOpeningElement): void {
+    private validateAnchor(parent: ts.Node, openingElement: ts.JsxOpeningLikeElement): void {
         if (openingElement.tagName.getText() === 'a') {
 
             const anchorInfo: AnchorInfo = {
@@ -138,7 +138,7 @@ class ReactA11yAnchorsRuleWalker extends ErrorTolerantWalker {
         }
     }
 
-    private getAttribute(openingElement: ts.JsxOpeningElement, attributeName: string): string {
+    private getAttribute(openingElement: ts.JsxOpeningLikeElement, attributeName: string): string {
         const attributes: ts.NodeArray<ts.JsxAttribute | ts.JsxSpreadAttribute> = openingElement.attributes;
         let attributeValue: string;
 
@@ -181,7 +181,7 @@ class ReactA11yAnchorsRuleWalker extends ErrorTolerantWalker {
         return title;
     }
 
-    private imageAltAttribute(openingElement: ts.JsxOpeningElement): string {
+    private imageAltAttribute(openingElement: ts.JsxOpeningLikeElement): string {
         if (openingElement.tagName.getText() === 'img') {
             const altAttribute: string = this.getAttribute(openingElement, 'alt');
             if (altAttribute) {

--- a/src/reactA11yAriaUnsupportedElementsRule.ts
+++ b/src/reactA11yAriaUnsupportedElementsRule.ts
@@ -50,7 +50,7 @@ class ReactA11yAriaUnsupportedElementsWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private validateOpeningElement(node: ts.JsxOpeningElement): void {
+    private validateOpeningElement(node: ts.JsxOpeningLikeElement): void {
         const tagName: string = node.tagName.getText();
 
         if (!DOM_SCHEMA[tagName]) {

--- a/src/reactA11yEventHasRoleRule.ts
+++ b/src/reactA11yEventHasRoleRule.ts
@@ -47,7 +47,7 @@ class ReactA11yEventHasRoleWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private checkJsxOpeningElement(node: ts.JsxOpeningElement): void {
+    private checkJsxOpeningElement(node: ts.JsxOpeningLikeElement): void {
         const tagName: string = node.tagName.getText();
 
         if (!DOM_SCHEMA[tagName]) {

--- a/src/reactA11yImageButtonHasAltRule.ts
+++ b/src/reactA11yImageButtonHasAltRule.ts
@@ -43,7 +43,7 @@ class ReactA11yImageButtonHasAltWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private validateOpeningElement(node: ts.JsxOpeningElement): void {
+    private validateOpeningElement(node: ts.JsxOpeningLikeElement): void {
         const tagName: string = node.tagName.getText();
 
         if (tagName !== 'input') {

--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -65,7 +65,7 @@ class ImgHasAltWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private checkJsxOpeningElement(node: ts.JsxOpeningElement): void {
+    private checkJsxOpeningElement(node: ts.JsxOpeningLikeElement): void {
         // Tag name is sensitive on lowercase or uppercase, we shoudn't normalize tag names in this rule.
         const tagName: string = node.tagName.getText();
         const options: any[] = this.getOptions(); // tslint:disable-line:no-any

--- a/src/reactA11yLangRule.ts
+++ b/src/reactA11yLangRule.ts
@@ -60,7 +60,7 @@ class ReactA11yLangRuleWalker extends ErrorTolerantWalker {
         super.visitJsxElement(node);
     }
 
-    private validateOpeningElement(parent: ts.Node, openingElement: ts.JsxOpeningElement): void {
+    private validateOpeningElement(parent: ts.Node, openingElement: ts.JsxOpeningLikeElement): void {
         if (openingElement.tagName.getText() === 'html') {
             const attributes: ts.NodeArray<ts.JsxAttribute | ts.JsxSpreadAttribute> = openingElement.attributes;
             let langFound: boolean = false;

--- a/src/reactA11yMetaRule.ts
+++ b/src/reactA11yMetaRule.ts
@@ -44,7 +44,7 @@ class ReactA11yMetaRuleWalker extends ErrorTolerantWalker {
         this.validateOpeningElement(node, node);
     }
 
-    private validateOpeningElement(parent: ts.Node, openElement: ts.JsxOpeningElement): void {
+    private validateOpeningElement(parent: ts.Node, openElement: ts.JsxOpeningLikeElement): void {
         if (openElement.tagName.getText() === 'meta') {
             const attributes: ts.NodeArray<ts.JsxAttribute | ts.JsxSpreadAttribute> = openElement.attributes;
             attributes.forEach((parameter: ts.JsxAttribute | ts.JsxSpreadAttribute): void => {

--- a/src/reactA11yRoleHasRequiredAriaPropsRule.ts
+++ b/src/reactA11yRoleHasRequiredAriaPropsRule.ts
@@ -71,7 +71,7 @@ class A11yRoleHasRequiredAriaPropsWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private checkJsxElement(node: ts.JsxOpeningElement): void {
+    private checkJsxElement(node: ts.JsxOpeningLikeElement): void {
         const tagName: string = node.tagName.getText();
         const attributesInElement: { [propName: string]: ts.JsxAttribute } = getJsxAttributesFromJsxElement(node);
         const roleProp: ts.JsxAttribute = attributesInElement[ROLE_STRING];

--- a/src/reactA11yRoleSupportsAriaPropsRule.ts
+++ b/src/reactA11yRoleSupportsAriaPropsRule.ts
@@ -67,7 +67,7 @@ class A11yRoleSupportsAriaPropsWalker extends Lint.RuleWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private checkJsxElement(node: ts.JsxOpeningElement): void {
+    private checkJsxElement(node: ts.JsxOpeningLikeElement): void {
         const attributesInElement: { [propName: string]: ts.JsxAttribute } = getJsxAttributesFromJsxElement(node);
         const roleProp: ts.JsxAttribute = attributesInElement[ROLE_STRING];
         let roleValue: string;

--- a/src/reactAnchorBlankNoopenerRule.ts
+++ b/src/reactAnchorBlankNoopenerRule.ts
@@ -52,7 +52,7 @@ class ReactAnchorBlankNoopenerRuleWalker extends ErrorTolerantWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private validateOpeningElement(openingElement: ts.JsxOpeningElement): void {
+    private validateOpeningElement(openingElement: ts.JsxOpeningLikeElement): void {
         if (openingElement.tagName.getText() === 'a') {
 
             const allAttributes: { [propName: string]: ts.JsxAttribute } = getJsxAttributesFromJsxElement(openingElement);

--- a/src/reactIframeMissingSandboxRule.ts
+++ b/src/reactIframeMissingSandboxRule.ts
@@ -65,7 +65,7 @@ class ReactIframeMissingSandboxRuleWalker extends ErrorTolerantWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private handleJsxOpeningElement(node: ts.JsxOpeningElement): void {
+    private handleJsxOpeningElement(node: ts.JsxOpeningLikeElement): void {
         if (node.tagName.getText() !== 'iframe') {
             return;
         }

--- a/src/reactNoDangerousHtmlRule.ts
+++ b/src/reactNoDangerousHtmlRule.ts
@@ -91,7 +91,7 @@ class NoDangerousHtmlWalker extends ErrorTolerantWalker {
         super.visitJsxSelfClosingElement(node);
     }
 
-    private handleJsxOpeningElement(node: ts.JsxOpeningElement): void {
+    private handleJsxOpeningElement(node: ts.JsxOpeningLikeElement): void {
         node.attributes.forEach((attribute: ts.JsxAttribute | ts.JsxSpreadAttribute): void => {
             if (attribute.kind === SyntaxKind.current().JsxAttribute) {
                 const jsxAttribute: ts.JsxAttribute = <ts.JsxAttribute>attribute;

--- a/src/reactThisBindingIssueRule.ts
+++ b/src/reactThisBindingIssueRule.ts
@@ -128,7 +128,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
             if (this.isUnboundListener(attributeLikeElement)) {
                 const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
                 if (attribute.initializer.kind === SyntaxKind.current().StringLiteral) {
-                    return
+                    return;
                 }
                 const jsxExpression: ts.JsxExpression = attribute.initializer;
                 const propAccess: ts.PropertyAccessExpression = <ts.PropertyAccessExpression>jsxExpression.expression;
@@ -142,7 +142,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
             } else if (this.isAttributeAnonymousFunction(attributeLikeElement)) {
                 const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
                 if (attribute.initializer.kind === SyntaxKind.current().StringLiteral) {
-                    return
+                    return;
                 }
                 const jsxExpression: ts.JsxExpression = attribute.initializer;
                 const expression: ts.Expression = jsxExpression.expression;

--- a/src/reactThisBindingIssueRule.ts
+++ b/src/reactThisBindingIssueRule.ts
@@ -122,7 +122,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
         super.visitVariableDeclaration(node);
     }
 
-    private visitJsxOpeningElement(node: ts.JsxOpeningElement): void {
+    private visitJsxOpeningElement(node: ts.JsxOpeningLikeElement): void {
         // create violations if the listener is a reference to a class method that was not bound to 'this' in the constructor
         node.attributes.forEach((attributeLikeElement: ts.JsxAttribute | ts.JsxSpreadAttribute): void => {
             if (this.isUnboundListener(attributeLikeElement)) {

--- a/src/reactThisBindingIssueRule.ts
+++ b/src/reactThisBindingIssueRule.ts
@@ -127,6 +127,9 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
         node.attributes.forEach((attributeLikeElement: ts.JsxAttribute | ts.JsxSpreadAttribute): void => {
             if (this.isUnboundListener(attributeLikeElement)) {
                 const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
+                if (attribute.initializer.kind === SyntaxKind.current().StringLiteral) {
+                    return
+                }
                 const jsxExpression: ts.JsxExpression = attribute.initializer;
                 const propAccess: ts.PropertyAccessExpression = <ts.PropertyAccessExpression>jsxExpression.expression;
                 const listenerText: string = propAccess.getText();
@@ -138,6 +141,9 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
                 }
             } else if (this.isAttributeAnonymousFunction(attributeLikeElement)) {
                 const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
+                if (attribute.initializer.kind === SyntaxKind.current().StringLiteral) {
+                    return
+                }
                 const jsxExpression: ts.JsxExpression = attribute.initializer;
                 const expression: ts.Expression = jsxExpression.expression;
                 const start: number = expression.getStart();

--- a/src/tests/TestHelper.ts
+++ b/src/tests/TestHelper.ts
@@ -11,17 +11,17 @@ export module TestHelper {
     /**
      * This setting must point to your rule .js files.
      */
-    export let RULES_DIRECTORY: string = 'dist/src/';
+    export const RULES_DIRECTORY: string = 'dist/src/';
 
     /**
      * This setting must point to your formatter .js files.
      */
-    export let FORMATTER_DIRECTORY: string = 'customFormatters/';
+    export const FORMATTER_DIRECTORY: string = 'customFormatters/';
 
     /**
      * You must specify an encoding for file read/writes
      */
-    export let FILE_ENCODING: string = 'utf8';
+    export const FILE_ENCODING: string = 'utf8';
 
     export interface FailurePosition {
         character: number;

--- a/src/tests/reactA11yImgHasAltRuleTests.ts
+++ b/src/tests/reactA11yImgHasAltRuleTests.ts
@@ -203,12 +203,6 @@ const d = <img alt={''} /> `;
             {
               name: fileName,
               ruleName: ruleName,
-              startPosition: { character: 11, line: 4 },
-              failure: getFailureStringNoAlt('Picture')
-            },
-            {
-              name: fileName,
-              ruleName: ruleName,
               startPosition: { character: 11, line: 5 },
               failure: getFailureStringNoAlt('Picture')
             },
@@ -216,12 +210,18 @@ const d = <img alt={''} /> `;
               name: fileName,
               ruleName: ruleName,
               startPosition: { character: 11, line: 6 },
-              failure: getFailureStringNoAlt('img')
+              failure: getFailureStringNoAlt('Picture')
             },
             {
               name: fileName,
               ruleName: ruleName,
               startPosition: { character: 11, line: 7 },
+              failure: getFailureStringNoAlt('img')
+            },
+            {
+              name: fileName,
+              ruleName: ruleName,
+              startPosition: { character: 11, line: 8 },
               failure: getFailureStringNoAlt('img')
             }
           ]
@@ -287,12 +287,6 @@ const d = <img alt={''} /> `;
             {
               name: fileName,
               ruleName: ruleName,
-              startPosition: { character: 11, line: 4 },
-              failure: getFailureStringEmptyAltAndNotPresentationRole('Picture')
-            },
-            {
-              name: fileName,
-              ruleName: ruleName,
               startPosition: { character: 11, line: 5 },
               failure: getFailureStringEmptyAltAndNotPresentationRole('Picture')
             },
@@ -306,7 +300,7 @@ const d = <img alt={''} /> `;
               name: fileName,
               ruleName: ruleName,
               startPosition: { character: 11, line: 7 },
-              failure: getFailureStringEmptyAltAndNotPresentationRole('img')
+              failure: getFailureStringEmptyAltAndNotPresentationRole('Picture')
             },
             {
               name: fileName,
@@ -318,6 +312,12 @@ const d = <img alt={''} /> `;
               name: fileName,
               ruleName: ruleName,
               startPosition: { character: 11, line: 9 },
+              failure: getFailureStringEmptyAltAndNotPresentationRole('img')
+            },
+            {
+              name: fileName,
+              ruleName: ruleName,
+              startPosition: { character: 11, line: 10 },
               failure: getFailureStringEmptyAltAndNotPresentationRole('img')
             }
           ]

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -107,26 +107,26 @@ export module AstUtils {
 
     export function isPrivate(node: ts.Node) : boolean {
         /* tslint:disable:no-bitwise */
-        return !!(node.flags & ts.NodeFlags.Private);
-        /* tslint:enable:no-bitwise */
+        return !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Private);
+        /* tslint:disable:no-bitwise */
     }
 
     export function isProtected(node: ts.Node) : boolean {
         /* tslint:disable:no-bitwise */
-        return !!(node.flags & ts.NodeFlags.Protected);
-        /* tslint:enable:no-bitwise */
+        return !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Protected);
+        /* tslint:disable:no-bitwise */
     }
 
     export function isPublic(node: ts.Node) : boolean {
         /* tslint:disable:no-bitwise */
-        return !!(node.flags & ts.NodeFlags.Public);
-        /* tslint:enable:no-bitwise */
+        return !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Public);
+        /* tslint:disable:no-bitwise */
     }
 
     export function isStatic(node: ts.Node) : boolean {
         /* tslint:disable:no-bitwise */
-        return !!(node.flags & ts.NodeFlags.Static);
-        /* tslint:enable:no-bitwise */
+        return !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Static);
+        /* tslint:disable:no-bitwise */
     }
 
     function isBindingPattern(node: ts.Node): node is ts.BindingPattern {
@@ -174,7 +174,7 @@ export module AstUtils {
 
     export function isExported(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        return !!(getCombinedNodeFlags(node) & ts.NodeFlags.Export);
+        return !!(getCombinedNodeFlags(node) & ts.ModifierFlags.Export);
         /* tslint:enable:no-bitwise */
     }
 

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -266,10 +266,7 @@ export module AstUtils {
         if (node.kind === SyntaxKind.current().PrefixUnaryExpression || node.kind === SyntaxKind.current().PostfixUnaryExpression) {
             const expression: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression =
                 <ts.PostfixUnaryExpression | ts.PrefixUnaryExpression>node;
-            const kind: ts.SyntaxKind = expression.operator;
-            if (kind >= SyntaxKind.current().FirstBinaryOperator && kind <= SyntaxKind.current().LastBinaryOperator) {
-                return isConstantExpression(expression.operand);
-            }
+            return isConstantExpression(expression.operand);
         }
         return isConstant(node);
     }

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -14,7 +14,7 @@ export module AstUtils {
         }
     }
 
-    export function getFunctionName(node : ts.CallExpression) : string {
+    export function getFunctionName(node : ts.CallExpression | ts.NewExpression) : string {
         const expression: ts.Expression = node.expression;
         let functionName : string = (<any>expression).text;
         if (functionName === undefined && (<any>expression).name) {

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -174,7 +174,7 @@ export module AstUtils {
 
     export function isExported(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        return !!(getCombinedNodeFlags(node) & ts.ModifierFlags.Export);
+        return !!(getCombinedNodeFlags(node) & ts.NodeFlags.ExportContext);
         /* tslint:enable:no-bitwise */
     }
 

--- a/src/utils/BaseFormatter.ts
+++ b/src/utils/BaseFormatter.ts
@@ -10,12 +10,12 @@ import {RuleFailure} from 'tslint/lib/language/rule/rule';
 export class BaseFormatter extends AbstractFormatter {
 
     private ruleName: string;
-    private applyFix: (failure: RuleFailure) => void;
+    private applyFix: (this: BaseFormatter, failure: RuleFailure) => void;
 
-    constructor(ruleName: string, applyFix: (failure: RuleFailure) => void) {
+    constructor(ruleName: string, applyFix: (this: BaseFormatter, failure: RuleFailure) => void) {
         super();
         this.ruleName = ruleName;
-        this.applyFix = applyFix;
+        this.applyFix = applyFix.bind(this);
     }
 
     public format(allFailures: RuleFailure[]): string {

--- a/src/utils/JsxAttribute.ts
+++ b/src/utils/JsxAttribute.ts
@@ -183,7 +183,7 @@ export function getJsxAttributesFromJsxElement(node: ts.Node): { [propName: stri
  * @return { ts.JsxElement | ts.JsxSelfClosingElement } - a element.
  */
 export function getJsxElementFromCode(code: string, exceptTagName: string): ts.JsxElement | ts.JsxSelfClosingElement {
-    const sourceFile: ts.SourceFile = ts.createSourceFile('test.tsx', code, ts.ScriptTarget.ES6, true);
+    const sourceFile: ts.SourceFile = ts.createSourceFile('test.tsx', code, ts.ScriptTarget.ES2015, true);
 
     return delintNode(sourceFile, exceptTagName);
 }

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasEmptyAltValueAndNotPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasEmptyAltValueAndNotPresentationRole.tsx
@@ -1,6 +1,6 @@
 import React = require('react');
 
-let Picture = (props) => <img />;
+let Picture = (props) => <span />;
 
 const a = <Picture alt='' />
 const b = <Picture alt role='button img' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasEmptyAltValueAndNotPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasEmptyAltValueAndNotPresentationRole.tsx
@@ -1,6 +1,7 @@
 import React = require('react');
 
-let Picture;
+let Picture = (props) => <img />;
+
 const a = <Picture alt='' />
 const b = <Picture alt role='button img' />
 const c = <Picture alt={''} role='button' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNoAltProp.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNoAltProp.tsx
@@ -1,6 +1,6 @@
 import React = require('react');
 
-let Picture = (props) => <img />;
+let Picture = (props) => <span />;
 
 const a = <Picture />
 const b = <Picture role='button img' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNoAltProp.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNoAltProp.tsx
@@ -1,6 +1,7 @@
 import React = require('react');
 
-let Picture;
+let Picture = (props) => <img />;
+
 const a = <Picture />
 const b = <Picture role='button img' />
 const c = <img notAltProp='propValue' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNonEmptyAltValueAndPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNonEmptyAltValueAndPresentationRole.tsx
@@ -1,6 +1,6 @@
 import React = require('react');
 
-let Picture;
+let Picture = (props) => <img />;
 let altValue;
 
 const a = <Picture alt='altValue' role='presentation' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNonEmptyAltValueAndPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/FailingTestInputs/CustomElementHasNonEmptyAltValueAndPresentationRole.tsx
@@ -1,6 +1,6 @@
 import React = require('react');
 
-let Picture = (props) => <img />;
+let Picture = (props) => <span />;
 let altValue;
 
 const a = <Picture alt='altValue' role='presentation' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/PassingTestInputs/CustomElementHasNonEmptyAltValueAndNotPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/PassingTestInputs/CustomElementHasNonEmptyAltValueAndNotPresentationRole.tsx
@@ -1,6 +1,6 @@
 import React = require('react');
 
-let Picture = (props) => <img />;
+let Picture = (props) => <span />;
 let validAltValue;
 
 const a = <Picture alt='validAltValue' role='button' />

--- a/test-data/a11yImgHasAlt/CustomElementTests/PassingTestInputs/CustomElementHasNonEmptyAltValueAndNotPresentationRole.tsx
+++ b/test-data/a11yImgHasAlt/CustomElementTests/PassingTestInputs/CustomElementHasNonEmptyAltValueAndNotPresentationRole.tsx
@@ -1,6 +1,7 @@
 import React = require('react');
 
-let Picture, validAltValue;
+let Picture = (props) => <img />;
+let validAltValue;
 
 const a = <Picture alt='validAltValue' role='button' />
 const b = <Picture alt={validAltValue} role='link' />

--- a/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementNotLowerCase.tsx
+++ b/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementNotLowerCase.tsx
@@ -1,7 +1,7 @@
 import React = require('react');
 
-let Img;
-let IMG;
+let Img = (props) => <img />;
+let IMG = (props) => <img />;
 
 const a = <Img />
 const b = <IMG alt=''/>

--- a/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementNotLowerCase.tsx
+++ b/test-data/a11yImgHasAlt/DefaltTests/PassingTestInputs/ImgElementNotLowerCase.tsx
@@ -1,7 +1,7 @@
 import React = require('react');
 
-let Img = (props) => <img />;
-let IMG = (props) => <img />;
+let Img = (props) => <span />;
+let IMG = (props) => <span />;
 
 const a = <Img />
 const b = <IMG alt=''/>


### PR DESCRIPTION
There were a few breaking changes in TS 2.1 in typings (`NodeFlags` split into `NodeFlags` and `ModifierFlags`, `ScriptTarget.ES6` renamed to `ScriptTarget.ES2016`, some changes in JSX definitions)

Plus, the compiler still has [bug (?)](https://github.com/Microsoft/TypeScript/issues/8060) regarding callback referencing `this` inside and passed to `super()`

This PR, hopefully, fixes all of them