### PR TITLE
Reenable linting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -463,7 +463,7 @@ module.exports = function(grunt) {
         'copy:json',
         'ts',
         'mochaTest',
-        //'tslint', // commented out until grunt-tslint supports tslint 4.0
+        'tslint',
         'validate-documentation',
         'validate-config',
         'validate-debug-mode',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -335,7 +335,12 @@ module.exports = function(grunt) {
             'no-inferrable-types': true,
             'only-arrow-functions': true,
             'ordered-imports': true,
-            'typedef-whitespace': true
+            'typedef-whitespace': true,
+            'array-type': true,
+            'completed-docs': true,
+            'cyclomatic-complexity': true,
+            'file-header': true,
+            'max-classes-per-file': true
         };
         var errors = [];
         getAllRuleNames().forEach(function(ruleName) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-mocha-test": "0.12.7",
     "grunt-ts": "5.4.0",
+    "grunt-tslint": "4.0.0",
     "load-grunt-tasks": "3.2.0",
     "mocha": "2.2.5",
     "time-grunt": "1.2.1",

--- a/src/noForInRule.ts
+++ b/src/noForInRule.ts
@@ -28,7 +28,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         (initializer: string, expression: string ) => {
             //tslint:disable-next-line:max-line-length
             return `Do not use the 'for in' statement: 'for (${initializer} in ${expression})'. If this is an object, use 'Object.keys' instead. If this is an array use a standard 'for' loop instead.`;
-        };
+        }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoForInRuleWalker(sourceFile, this.getOptions()));

--- a/src/preferConstRule.ts
+++ b/src/preferConstRule.ts
@@ -27,7 +27,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_STRING_FACTORY: (identifier: string) => string =
         (identifier: string) => `Identifier '${identifier}' never appears ` +
-            'on the LHS of an assignment - use const instead of let for its declaration.';
+            'on the LHS of an assignment - use const instead of let for its declaration.'
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new PreferConstWalker(sourceFile, this.getOptions()));

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,7 @@
 {
+  "rulesDirectory": [
+    "dist/src"
+  ],
   "rules": {
     "react-a11y-aria-unsupported-elements": true,
     "react-a11y-event-has-role": true,
@@ -216,11 +219,11 @@
     "possible-timing-attack": true,
     "non-literal-require": true,
     "adjacent-overload-signatures": false,
-    "array-type": false,
-    "completed-docs": false,
-    "cyclomatic-complexity": false,
-    "file-header": false,
-    "max-classes-per-file": false,
+    "array-type": [false],
+    "completed-docs": [false],
+    "cyclomatic-complexity": [false],
+    "file-header": [false],
+    "max-classes-per-file": [false],
     "no-parameter-properties": false,
     "object-literal-shorthand": false,
     "prefer-for-of": false


### PR DESCRIPTION
Linting of ts files was previously disabled. Grunt-tslint 4 now published supports tslint >= 4. Source linting has now been re-enabled.