### PR TITLE
Stop errors with TSLint 4.3.1

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -53,7 +53,7 @@ module.exports = {
         "no-duplicate-case": true,
         "no-duplicate-variable": true,
         "no-empty": true,
-        "no-for-in-array": true,
+        "no-for-in-array": false,
         "no-increment-decrement": true,
         "no-invalid-regexp": true,
         "no-invalid-this": true,
@@ -73,7 +73,7 @@ module.exports = {
         "radix": true,
         "react-this-binding-issue": true,
         "react-unused-props-and-state": true,
-        "restrict-plus-operands": true, // the plus operand should really only be used for strings and numbers
+        "restrict-plus-operands": false, // the plus operand should really only be used for strings and numbers
         "switch-default": true,
         "triple-equals": [true, "allow-null-check"],
         "use-isnan": true,
@@ -205,8 +205,8 @@ module.exports = {
         "no-missing-visibility-modifiers": false, // use tslint member-access rule instead
         "no-multiple-var-decl": false,         // use tslint one-variable-per-declaration rule instead
         "no-switch-case-fall-through": false,  // now supported by TypeScript compiler
-        "no-unused-imports": false,            // use tslint no-unused-variable rule instead
-        "no-unused-variable": false,           // now supported by TypeScript 2.0 compiler
-    }
+        "no-unused-imports": false             // Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead
+//        "no-unused-variable": true             // Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead
+   }
 };
 


### PR DESCRIPTION
This PR is for discussion  - I disabled a couple of rules as they cause errors

Using TSLint 4.3.1.

and TSLint.json

```
{
    "rulesDirectory": ["node_modules/tslint-microsoft-contrib/"],    
    "extends": "tslint-microsoft-contrib/recommended_ruleset.js",
    "rules": {
        "interface-name": [true, "never-prefix"],
        "semicolon": [true, "never"],
        "linebreak-style": [true, "LF"],
        "quotemark": [true, "single", "avoid-escape"]
    }
}
```

These are the issues: Comments here as inline comments not working - perhaps and Edge bug.

* Waring: ```no-unused-variable``` is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
  * I commend it out an moved to depreciated section
* Error ```restrict-plus-operands``` requires type checking
  * I turned it off
* Error ```restrict-plus-operands``` requires type checking
  * I turned it off

Here's the full trace for the first error

```no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
C:\projects\spikes\tsplay\node_modules\tslint\lib\runner.js:117
            throw error;
            ^

Error: no-for-in-array requires type checking
    at Rule.TypedRule.apply (C:\projects\spikes\tsplay\node_modules\tslint\lib\language\rule\typedRule.js:34:15)
    at Linter.applyRule (C:\projects\spikes\tsplay\node_modules\tslint\lib\linter.js:143:33)
    at Linter.lint (C:\projects\spikes\tsplay\node_modules\tslint\lib\linter.js:109:41)
    at Runner.processFiles (C:\projects\spikes\tsplay\node_modules\tslint\lib\runner.js:154:20)
    at Runner.run (C:\projects\spikes\tsplay\node_modules\tslint\lib\runner.js:109:18)
    at Object.<anonymous> (C:\projects\spikes\tsplay\node_modules\tslint\lib\tslint-cli.js:138:6)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```

