### PR TITLE
Remove no-unused-variable to suppress tslint warning

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -219,7 +219,8 @@ module.exports = {
         "no-multiple-var-decl": false,         // use tslint one-variable-per-declaration rule instead
         "no-switch-case-fall-through": false,  // now supported by TypeScript compiler
         "no-unused-imports": false,            // use tslint no-unused-variable rule instead
-        "no-unused-variable": false,           // now supported by TypeScript 2.0 compiler
+        // "no-unused-variable": false,        // now supported by TypeScript 2.0 compiler
+                    // loading this rule will be warned even it is false
         "typeof-compare": false,               // the valid-typeof rule is currently superior to this version
     }
 };


### PR DESCRIPTION
Now tslint shows warning if we load `no-unused-variable` even it is false.

In tslint side, it is already removed from recommended config. ( palantir/tslint#1748 )