### PR TITLE
Ensure LF line endings are used upon git checkout.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+* text eol=lf


### PR DESCRIPTION
Getting latest from master and simply running `grunt all` on my Windows 10 machine produced **a lot** of linting errors about line endings

![lots of errors](https://cloud.githubusercontent.com/assets/463685/23993973/2e8bac7e-0a19-11e7-99a7-60069bed322c.png)

 quick google brought me to [this page](https://help.github.com/articles/dealing-with-line-endings), where I added the line line to the `.gitattrubutes` file (which is the only change in this PR) & then ran the commands to refresh my local repo with the new settings, and now I get zero errors.

![no errors no](https://cloud.githubusercontent.com/assets/463685/23994088/aad74b6c-0a19-11e7-8abd-8c576ecf9ca0.png)