### PR TITLE
Fix the new rule snippet to not create an immediately broken file

### DIFF
--- a/templates/rule.snippet
+++ b/templates/rule.snippet
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import * as Lint from 'tslint/lib/lint';
+import * as Lint from 'tslint';
 
 import {ErrorTolerantWalker} from './utils/ErrorTolerantWalker';
 import {ExtendedMetadata} from './utils/ExtendedMetadata';
@@ -20,6 +20,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',    // one of: 'functionality' | 'maintainability' | 'style' | 'typescript'
         description: '... add a meaningful one line description',
         options: null,
+        optionsDescription: '',
+        optionExamples: [],         //Remove this property if the rule has no options
+        typescriptOnly: false,
         issueClass: 'Non-SDL',      // one of: 'SDL' | 'Non-SDL' | 'Ignored'
         issueType: 'Warning',       // one of: 'Error' | 'Warning'
         severity: 'Low',            // one of: 'Critical' | 'Important' | 'Moderate' | 'Low'


### PR DESCRIPTION
I wanted to create a new rule for this project, so I followed the instructions and ran
```
grunt create-rule --rule-name=my-new-rule
```
which created a broken rule file that I had to figure out why it was broken before I could start developing.  This PR should fix the incorrect path to `tslint` and add the missing required properties to the `metadata` class member.

Perhaps some tests should be added for this project that creates a rule with this command and ensures that it can be compiled?