### PR TITLE
[#371] relax tsutils peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   },
   "peerDependencies": {
     "tslint": ">=5.1.0",
-    "tsutils": "1.6.0"
+    "tsutils": ">=1.6.0"
   }
 }


### PR DESCRIPTION
To prevent warning when using newer tsutils version:

```
warning "tslint-microsoft-contrib@5.0.0" has incorrect peer dependency "tsutils@1.6.0".
```