### PR TITLE
Only return expression length to stop annoying whole block underlining

### DIFF
--- a/src/mochaAvoidOnlyRule.ts
+++ b/src/mochaAvoidOnlyRule.ts
@@ -50,13 +50,13 @@ class MochaAvoidOnlyRuleWalker extends ErrorTolerantWalker {
                     if (node.arguments[1].kind === ts.SyntaxKind.FunctionExpression
                         || node.arguments[1].kind === ts.SyntaxKind.ArrowFunction) {
                         if (node.expression.getText() === 'it.only') {
-                            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_IT);
+                            this.addFailureAt(node.getStart(),  node.expression.getText().length, Rule.FAILURE_STRING_IT);
                         } else if (node.expression.getText() === 'specify.only') {
-                            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_SPECIFY);
+                            this.addFailureAt(node.getStart(),  node.expression.getText().length, Rule.FAILURE_STRING_SPECIFY);
                         } else if (node.expression.getText() === 'describe.only') {
-                            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_DESCRIBE);
+                            this.addFailureAt(node.getStart(),  node.expression.getText().length, Rule.FAILURE_STRING_DESCRIBE);
                         } else if (node.expression.getText() === 'context.only') {
-                            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_CONTEXT);
+                            this.addFailureAt(node.getStart(),  node.expression.getText().length, Rule.FAILURE_STRING_CONTEXT);
                         }
                     }
                 }


### PR DESCRIPTION
While developing you often want to select one set of tests to run. In vs code because mocha-avoid-only returns the entire length of the block, every single line gets underlined, making it difficult to ignore and dev against.

![screen shot 2017-05-23 at 10 57 12 am](https://cloud.githubusercontent.com/assets/3658522/26334416/4afea7d4-3fa8-11e7-855c-17c8a74e7606.png)

vs

![screen shot 2017-05-23 at 10 58 10 am](https://cloud.githubusercontent.com/assets/3658522/26334421/5182849a-3fa8-11e7-926d-78001f276b48.png)

