### PR TITLE
Add auto-fixer for the import-name rule

### DIFF
--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -1,3 +1,4 @@
+// tslint:disable:linebreak-style no-multiline-string quotemark object-literal-key-quotes
 import {TestHelper} from './TestHelper';
 
 /**
@@ -43,13 +44,23 @@ describe('importNameRule', () : void => {
                 "failure": "Misnamed import. Import should be named 'App' but found 'MyCoolApp'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 2 }
+                "startPosition": { "character": 13, "line": 2 },
+                "fix": {
+                    "innerStart": 20,
+                    "innerLength": 9,
+                    "innerText": "App"
+                }
             },
             {
                 "failure": "Misnamed import. Import should be named 'App' but found 'MyCoolApp2'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 3 }
+                "startPosition": { "character": 13, "line": 3 },
+                "fix": {
+                    "innerStart": 67,
+                    "innerLength": 10,
+                    "innerText": "App"
+                }
             }
         ]);
     });
@@ -65,13 +76,23 @@ describe('importNameRule', () : void => {
                 "failure": "Misnamed import. Import should be named 'App' but found 'MyCoolApp'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 2 }
+                "startPosition": { "character": 13, "line": 2 },
+                "fix": {
+                    "innerStart": 20,
+                    "innerLength": 9,
+                    "innerText": "App"
+                }
             },
             {
                 "failure": "Misnamed import. Import should be named 'App' but found 'MyCoolApp2'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 3 }
+                "startPosition": { "character": 13, "line": 3 },
+                "fix": {
+                    "innerStart": 61,
+                    "innerLength": 10,
+                    "innerText": "App"
+                }
             }
         ]);
     });
@@ -86,7 +107,12 @@ describe('importNameRule', () : void => {
                 "failure": "Misnamed import. Import should be named 'DependencyManager' but found 'Service'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 2 }
+                "startPosition": { "character": 13, "line": 2 },
+                "fix": {
+                    "innerStart": 20,
+                    "innerLength": 7,
+                    "innerText": "DependencyManager"
+                }
             }
         ]);
     });
@@ -101,7 +127,12 @@ describe('importNameRule', () : void => {
                 "failure": "Misnamed import. Import should be named 'userSettingsPage' but found 'UserSettings'",
                 "name": "file.ts",
                 "ruleName": "import-name",
-                "startPosition": { "character": 13, "line": 2 }
+                "startPosition": { "character": 13, "line": 2 },
+                "fix": {
+                    "innerStart": 20,
+                    "innerLength": 12,
+                    "innerText": "userSettingsPage"
+                }
             }
         ]);
     });

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -1,4 +1,3 @@
-// tslint:disable:linebreak-style no-multiline-string quotemark object-literal-key-quotes
 import {TestHelper} from './TestHelper';
 
 /**

--- a/src/tests/TestHelper.ts
+++ b/src/tests/TestHelper.ts
@@ -33,6 +33,11 @@ export module TestHelper {
         line: number;
         position?: number;
     }
+    export interface Fix {
+        innerStart: number;
+        innerLength: number;
+        innerText: string;
+    }
     export interface ExpectedFailure {
         ruleName: string;
         name: string;
@@ -40,6 +45,7 @@ export module TestHelper {
         ruleSeverity?: string;
         endPosition?: FailurePosition;
         startPosition: FailurePosition;
+        fix?: Fix;
     }
 
     export function assertNoViolation(ruleName: string,


### PR DESCRIPTION
Now the `import-name` rule can be auto-fixed!

![auto-fix](https://user-images.githubusercontent.com/463685/28133405-ebfe7ace-670d-11e7-9743-17c5c3f14b44.gif)

(Note: this only update the actual `import` statement, and not all of the references to the old name)