### PR TITLE
Add 'typescript' to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "underscore": "1.8.3"
   },
   "peerDependencies": {
-    "tslint": ">=5.1.0",
-    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev"
+    "tslint": "^5.1.0",
+    "typescript": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,18 @@
   },
   "author": "Hamlet D'Arcy",
   "contributors": [
-    { "name": "Bernd Kiefer",   "email": "bernd.kiefer@microsoft.com" },
-    { "name": "Daniel Manesku", "email": "daniel.manesku@microsoft.com" },
-    { "name": "Hamlet D'Arcy",  "email": "hamlet.darcy@microsoft.com" }
+    {
+      "name": "Bernd Kiefer",
+      "email": "bernd.kiefer@microsoft.com"
+    },
+    {
+      "name": "Daniel Manesku",
+      "email": "daniel.manesku@microsoft.com"
+    },
+    {
+      "name": "Hamlet D'Arcy",
+      "email": "hamlet.darcy@microsoft.com"
+    }
   ],
   "bugs": {
     "url": "https://github.com/Microsoft/tslint-microsoft-contrib/issues"
@@ -46,6 +55,7 @@
     "underscore": "1.8.3"
   },
   "peerDependencies": {
-    "tslint": ">=5.1.0"
+    "tslint": ">=5.1.0",
+    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev"
   }
 }


### PR DESCRIPTION
Most files import "typescript" but typescript isn't depended on in package.json.  You usually don't notice because typescript is installed by other modules (e.g. tslint), but it isn't proper.

Like tslint, I put typescript in the peerDependencies and I used the version range that tslint 5.1 also has in its peerDepdenencies for typescript.

