### PR TITLE
Use ReadonlyArray for node arrays

### DIFF
--- a/src/noUnnecessaryOverrideRule.ts
+++ b/src/noUnnecessaryOverrideRule.ts
@@ -63,7 +63,7 @@ class NoUnnecessaryOverrideRuleWalker extends ErrorTolerantWalker {
             return false; // different param list lengths means they do not match
         }
 
-        const allParameters: ts.ParameterDeclaration[] = node.parameters;
+        const allParameters: ReadonlyArray<ts.ParameterDeclaration> = node.parameters;
         /* tslint:disable:no-increment-decrement */
         for (let i = 0; i < allParameters.length; i++) {
         /* tslint:enable:no-increment-decrement */

--- a/src/utils/JsxAttribute.ts
+++ b/src/utils/JsxAttribute.ts
@@ -142,10 +142,10 @@ export function getNumericLiteral(node: ts.JsxAttribute): string {
  * It contains JsxAttribute and JsxSpreadAttribute.
  */
 export function getAllAttributesFromJsxElement(node: ts.Node): ts.NodeArray<ts.JsxAttributeLike> {
-    let attributes: ts.NodeArray<ts.JsxAttributeLike>;
+    let attributes: ts.NodeArray<ts.JsxAttributeLike> = null;
 
     if (node == null) {
-        return <ts.NodeArray<ts.JsxAttributeLike>>[];
+        return attributes;
     } else if (isJsxElement(node)) {
         attributes = node.openingElement.attributes.properties;
     } else if (isJsxSelfClosingElement(node)) {

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -35,7 +35,7 @@ export class Scope {
         return false;
     }
 
-    public addParameters(parameters: ts.ParameterDeclaration[]): void {
+    public addParameters(parameters: ReadonlyArray<ts.ParameterDeclaration>): void {
         parameters.forEach((parm: ts.ParameterDeclaration): void => {
             if (AstUtils.isDeclarationFunctionType(parm)) {
                 this.addFunctionSymbol(parm.name.getText());

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -6,7 +6,7 @@ export module Utils {
     /**
      * Logical 'any' or 'exists' function.
      */
-    export function exists<T>(list : T[], predicate: (t: T) => boolean) : boolean {
+    export function exists<T>(list : ReadonlyArray<T>, predicate: (t: T) => boolean) : boolean {
         if (list != null ) {
             for (let i = 0; i < list.length; i++) {
                 const obj : T = list[i];
@@ -21,7 +21,7 @@ export module Utils {
     /**
      * A contains function.
      */
-    export function contains<T>(list: T[], element: T): boolean {
+    export function contains<T>(list: ReadonlyArray<T>, element: T): boolean {
         return exists(list, (item: T): boolean => {
             return item === element;
         });
@@ -30,7 +30,7 @@ export module Utils {
     /**
      * A removeAll function.
      */
-    export function removeAll<T>(source: T[], elementsToRemove: T[]): T[] {
+    export function removeAll<T>(source: ReadonlyArray<T>, elementsToRemove: ReadonlyArray<T>): T[] {
         if (source == null || source.length === 0) {
             return [];
         }
@@ -46,7 +46,7 @@ export module Utils {
     /**
      * A remove() function.
      */
-    export function remove<T>(source: T[], elementToRemove: T): T[] {
+    export function remove<T>(source: ReadonlyArray<T>, elementToRemove: T): T[] {
         return removeAll(source, [elementToRemove]);
     }
 


### PR DESCRIPTION
TypeScript 2.5 (Microsoft/TypeScript#17213) specified the NodeArray type to be readonly. This doesn't change the run-time behavior but will cause compile-time errors if compiling against ts2.5.
Changing types for node arrays to ReadonlyArray fixes the problem.