### PR TITLE
add grunt rule to generate rule-metadata.json which contains all rule…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tslint-microsoft-contrib.iml
 .npm_cache
 
 out.html
+rule-metadata.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,6 +384,18 @@ module.exports = function(grunt) {
 
     });
 
+    grunt.registerTask('generate-rule-metadata', 'A task that generates rule-metadata.json which contains a json array of all rule metadata', function () {
+
+        const allMetadata = []
+
+        getAllRules().forEach(function(ruleFile) {
+            const metadata = getMetadataFromFile(ruleFile)
+            allMetadata.push(metadata)
+        })
+
+        grunt.file.write('rule-metadata.json', JSON.stringify(allMetadata, null, 2), {encoding: 'UTF-8'});
+    });
+
     grunt.registerTask('generate-recommendations', 'A task that generates the recommended_ruleset.js file', function () {
 
         const groupedRows = {};
@@ -476,6 +488,7 @@ module.exports = function(grunt) {
         'generate-recommendations',
         'generate-default-tslint-json',
         'generate-sdl-report',
+        'generate-rule-metadata',
         'create-package-json-for-npm'
     ]);
 


### PR DESCRIPTION
… metadata as a json array for use in other tools

Hi maintaiers,

I needed to extract all the rule metadata for one of my projects. I figured this could be useful for other people too. Let me know if you think anything needs to be changed or if this isn't valuable.

Best,
Drew 