### PR TITLE
proposed type-checking for noStringBased rules

### DIFF
--- a/src/utils/NoStringParameterToFunctionCallWalker.ts
+++ b/src/utils/NoStringParameterToFunctionCallWalker.ts
@@ -27,8 +27,21 @@ export class NoStringParameterToFunctionCallWalker extends ScopedSymbolTrackingW
 
     private validateExpression(node : ts.CallExpression) : void {
         const functionName : string = AstUtils.getFunctionName(node);
+        const functionTarget : string = AstUtils.getFunctionTarget(node);
+        const functionTargetType : string = this.getFunctionTargetType(node);
         const firstArg : ts.Expression = node.arguments[0];
         if (functionName === this.targetFunctionName && firstArg != null) {
+            if (functionTarget) {
+                if (functionTargetType) {
+                    if (!functionTargetType.match(/^(any|Window|Worker)$/)) {
+                        return;
+                    }
+                } else {
+                    if (!functionTarget.match(/^(this|window)$/)) {
+                        return;
+                    }
+                }
+            }
             if (!this.isExpressionEvaluatingToFunction(firstArg)) {
                 const msg : string = this.failureString + firstArg.getFullText().trim().substring(0, 40);
                 this.addFailureAt(node.getStart(), node.getWidth(), msg);

--- a/src/utils/ScopedSymbolTrackingWalker.ts
+++ b/src/utils/ScopedSymbolTrackingWalker.ts
@@ -21,6 +21,15 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
         }
     }
 
+    protected getFunctionTargetType(expression: ts.CallExpression) : string {
+        if (expression.expression.kind === ts.SyntaxKind.PropertyAccessExpression && this.typeChecker) {
+            const propExp : ts.PropertyAccessExpression = <ts.PropertyAccessExpression>expression.expression;
+            const targetType: ts.Type = this.typeChecker.getTypeAtLocation(propExp.expression);
+            return this.typeChecker.typeToString(targetType);
+        }
+        return null;
+    }
+
     protected isExpressionEvaluatingToFunction(expression : ts.Expression) : boolean {
         if (expression.kind === ts.SyntaxKind.ArrowFunction
             || expression.kind === ts.SyntaxKind.FunctionExpression) {


### PR DESCRIPTION
I experienced false positives in `no-string-based-set-timeout` rule when `setTimeout` is called on [http.ClientRequest](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback) from module `http`. 

In this PR I am proposing to add additional type checks so that such FPs are eliminated. Existing tests are successful but we might need to test this on larger code base. 
