### PR TITLE
Fix no-function-expression failing generator functions

### DIFF
--- a/src/noFunctionExpressionRule.ts
+++ b/src/noFunctionExpressionRule.ts
@@ -39,7 +39,7 @@ class NoFunctionExpressionRuleWalker extends ErrorTolerantWalker {
             walker.walk(child);
         });
         // function expression that access 'this' is allowed
-        if (!walker.isAccessingThis) {
+        if (!walker.isAccessingThis && !node.asteriskToken) {
             this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
         }
         super.visitFunctionExpression(node);

--- a/src/tests/NoFunctionExpressionRuleTests.ts
+++ b/src/tests/NoFunctionExpressionRuleTests.ts
@@ -17,7 +17,16 @@ describe('noFunctionExpressionRule', (): void => {
 
     it('should pass on generator', (): void => {
         const script: string = `
-            var x = (): void => {
+            var x = function *() {
+            }
+        `;
+
+        TestHelper.assertViolations(ruleName, script, []);
+    });
+
+    it('should pass on named generator', (): void => {
+        const script: string = `
+            var x = function * namedGenerator() {
             }
         `;
 


### PR DESCRIPTION
As there is no arrow function possible for generator, no-function-expression should not fail with a generator, fixes #291 