### PR TITLE
Dedupe SUSPICIOUS_WORDS list for the no-suspicious-comment rule

### DIFF
--- a/src/noSuspiciousCommentRule.ts
+++ b/src/noSuspiciousCommentRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: ExtendedMetadata = {
         ruleName: 'no-suspicious-comment',
         type: 'maintainability',
-        description: 'Do not use suspicious comments, such as BUG, HACK, FIXME, LATER, LATER2, TODO',
+        description: `Do not use suspicious comments, such as ${SUSPICIOUS_WORDS.split(', ')}`,
         options: null,
         optionsDescription: '',
         typescriptOnly: true,


### PR DESCRIPTION
This reduces potential out-of-sync issue if one gets updated without the other, or if one day the list can be configured.