### PR TITLE
Allow HTTP scheme for localhost URLs

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -19,7 +19,7 @@ module.exports = {
         "no-eval": true,
         "no-exec-script": true,
         "no-function-constructor-with-string-args": true,
-        "no-http-string": [true, "http://www.example.com/?.*", "http://www.examples.com/?.*"],
+        "no-http-string": [true, "http://www.example.com/?.*", "http://www.examples.com/?.*", "http://localhost:?.*"],
         "no-inner-html": true,
         "no-octal-literal": true,
         "no-reserved-keywords": true,
@@ -263,4 +263,3 @@ module.exports = {
         "valid-typeof": false,
     }
 };
-

--- a/src/noHttpStringRule.ts
+++ b/src/noHttpStringRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         severity: 'Critical',
         level: 'Mandatory',
         group: 'Security',
-        recommendation: '[true, "http://www.example.com/?.*", "http://www.examples.com/?.*"],',
+        recommendation: '[true, "http://www.example.com/?.*", "http://www.examples.com/?.*", "http://localhost:?.*"],',
         commonWeaknessEnumeration: '319'
     };
 


### PR DESCRIPTION
In my experience, localhost URLs are almost exclusively used for development purposes, and setting up HTTPS for localhost URLs is really tedious, and most of the time unnecessary.

Note that I'm not completely sure of the syntax, so let me know if I'm wrong! The `:` at the end is on purpose to make sure all ports are allowed. I don't think it's worth the effort to allow `http://localhost/` without a port specifically, but let me know.

<img width="556" alt="screen shot 2018-04-19 at 17 59 29" src="https://user-images.githubusercontent.com/113730/39003588-71e7acc6-43fb-11e8-99f0-21cbef57098b.png">

(On an unrelated note, I suggest removing `http://examples.com`, it seems like a semi-real domain, and it's not part of https://en.wikipedia.org/wiki/Example.com / https://tools.ietf.org/html/rfc2606#section-3)