### PR TITLE
Disable the use of `console.error`

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -48,7 +48,7 @@ module.exports = {
         "no-backbone-get-set-outside-model": true,
         "no-bitwise": true,
         "no-conditional-assignment": true,
-        "no-console": [true, "debug", "info", "log", "time", "timeEnd", "trace"],
+        "no-console": [true, "debug", "error", "info", "log", "time", "timeEnd", "trace"],
         "no-constant-condition": true,
         "no-control-regex": true,
         "no-debugger": true,
@@ -263,4 +263,3 @@ module.exports = {
         "valid-typeof": false,
     }
 };
-

--- a/tslint.json
+++ b/tslint.json
@@ -91,6 +91,7 @@
     "no-console": [
       true,
       "debug",
+      "error",
       "info",
       "log",
       "time",


### PR DESCRIPTION
I have noticed that this project already locally disables this rule (as if it were present in the config) [here](https://github.com/astorije/tslint-microsoft-contrib/blame/master/src/functionNameRule.ts#L101-L103) and [here](https://github.com/astorije/tslint-microsoft-contrib/blame/master/src/reactUnusedPropsAndStateRule.ts#L71-L73) (the only 2 uses of `console.error` in this repo).

We realized `console.error` was not forbidden in the recommended configuration and think it would be a sane thing to enforce by default. I reckon this will be a breaking change however.