### PR TITLE
Only flag html method if jQuery (#425)

### DIFF
--- a/src/noInnerHtmlRule.ts
+++ b/src/noInnerHtmlRule.ts
@@ -7,7 +7,7 @@ import {ExtendedMetadata} from './utils/ExtendedMetadata';
 
 const FAILURE_INNER: string = 'Writing a string to the innerHTML property is insecure: ';
 const FAILURE_OUTER: string = 'Writing a string to the outerHTML property is insecure: ';
-const FAILURE_JQUERY: string = 'Using the html() function to write a string to innerHTML is insecure: ';
+const FAILURE_HTML_LIB: string = 'Using the html() function to write a string to innerHTML is insecure: ';
 
 /**
  * Implementation of the no-inner-html rule.
@@ -36,13 +36,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoInnerHtmlRuleWalker extends ErrorTolerantWalker {
 
-    private jqueryExpressionRegex: RegExp = /^(jquery|[$])/i;
+    private htmlLibExpressionRegex: RegExp = /^(jquery|[$])/i;
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
         const opt = this.getOptions();
-        if (typeof opt[1] === 'object' && opt[1]['jquery-matcher']) {
-            this.jqueryExpressionRegex = new RegExp(opt[1]['jquery-matcher']);
+        if (typeof opt[1] === 'object' && opt[1]['html-lib-matcher']) {
+            this.htmlLibExpressionRegex = new RegExp(opt[1]['html-lib-matcher']);
         }
     }
 
@@ -68,8 +68,8 @@ class NoInnerHtmlRuleWalker extends ErrorTolerantWalker {
         if (functionName === 'html') {
             if (node.arguments.length > 0) {
                 const functionTarget = AstUtils.getFunctionTarget(node);
-                if (this.jqueryExpressionRegex.test(functionTarget)) {
-                    this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_JQUERY + node.getText());
+                if (this.htmlLibExpressionRegex.test(functionTarget)) {
+                    this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_HTML_LIB + node.getText());
                 }
             }
         }

--- a/src/noInnerHtmlRule.ts
+++ b/src/noInnerHtmlRule.ts
@@ -56,7 +56,10 @@ class NoInnerHtmlRuleWalker extends ErrorTolerantWalker {
         const functionName = AstUtils.getFunctionName(node);
         if (functionName === 'html') {
             if (node.arguments.length > 0) {
-                this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_JQUERY + node.getText());
+                const functionTarget = AstUtils.getFunctionTarget(node);
+                if (AstUtils.isJQueryExpression(functionTarget)) {
+                    this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_JQUERY + node.getText());
+                }
             }
         }
         super.visitCallExpression(node);

--- a/src/tests/AstUtilsTests.ts
+++ b/src/tests/AstUtilsTests.ts
@@ -1,0 +1,38 @@
+import {AstUtils} from '../utils/AstUtils';
+import * as chai from 'chai';
+
+/**
+ * Unit tests.
+ */
+describe('AstUtils', () : void => {
+    describe('isJQuery', (): void => {
+        it('should match expected strings', (): void => {
+            chai.expect(AstUtils.isJQuery('$')).to.equal(true, 'short form');
+            chai.expect(AstUtils.isJQuery('jQuery')).to.equal(true, 'typical long form');
+            chai.expect(AstUtils.isJQuery('jquery')).to.equal(true, 'another long form');
+        });
+        it('should not match unexpected strings', (): void => {
+            chai.expect(AstUtils.isJQuery('S')).to.equal(false, 'Not jquery');
+            chai.expect(AstUtils.isJQuery('query')).to.equal(false, 'Also not jquery');
+        });
+    });
+    describe('isJQueryExpression', (): void => {
+        it('should match expected strings', (): void => {
+            chai.expect(AstUtils.isJQueryExpression('$')).to.equal(true, 'short form; base base');
+            chai.expect(AstUtils.isJQueryExpression('$(html)')).to.equal(true, 'short form; wrapper');
+            chai.expect(AstUtils.isJQueryExpression('$(html).children("div")')).to.equal(true, 'short form; wrapper; chained function');
+
+            chai.expect(AstUtils.isJQueryExpression('$someVar.children("div")')).to.equal(true, 'jQuery variable; chained');
+
+            chai.expect(AstUtils.isJQueryExpression('jQuery')).to.equal(true, 'typical long form; base');
+            chai.expect(AstUtils.isJQueryExpression('jquery')).to.equal(true, 'typical long form; case insensitive');
+            chai.expect(AstUtils.isJQueryExpression('jQuery(html)')).to.equal(true, 'typical long form; wrapper');
+            chai.expect(AstUtils.isJQueryExpression('jquery(body)')).to.equal(true, 'typical long form; wrapper; case insensitive');
+            chai.expect(AstUtils.isJQueryExpression('jquery("body").find("div")')).to.equal(true,
+              'typical long form; wrapper; case insensitive; chained');
+        });
+        it('should not match unexpected strings', (): void => {
+            chai.expect(AstUtils.isJQueryExpression('S')).to.equal(false, 'Not jquery');
+        });
+    });
+});

--- a/src/tests/AstUtilsTests.ts
+++ b/src/tests/AstUtilsTests.ts
@@ -16,23 +16,4 @@ describe('AstUtils', () : void => {
             chai.expect(AstUtils.isJQuery('query')).to.equal(false, 'Also not jquery');
         });
     });
-    describe('isJQueryExpression', (): void => {
-        it('should match expected strings', (): void => {
-            chai.expect(AstUtils.isJQueryExpression('$')).to.equal(true, 'short form; base base');
-            chai.expect(AstUtils.isJQueryExpression('$(html)')).to.equal(true, 'short form; wrapper');
-            chai.expect(AstUtils.isJQueryExpression('$(html).children("div")')).to.equal(true, 'short form; wrapper; chained function');
-
-            chai.expect(AstUtils.isJQueryExpression('$someVar.children("div")')).to.equal(true, 'jQuery variable; chained');
-
-            chai.expect(AstUtils.isJQueryExpression('jQuery')).to.equal(true, 'typical long form; base');
-            chai.expect(AstUtils.isJQueryExpression('jquery')).to.equal(true, 'typical long form; case insensitive');
-            chai.expect(AstUtils.isJQueryExpression('jQuery(html)')).to.equal(true, 'typical long form; wrapper');
-            chai.expect(AstUtils.isJQueryExpression('jquery(body)')).to.equal(true, 'typical long form; wrapper; case insensitive');
-            chai.expect(AstUtils.isJQueryExpression('jquery("body").find("div")')).to.equal(true,
-              'typical long form; wrapper; case insensitive; chained');
-        });
-        it('should not match unexpected strings', (): void => {
-            chai.expect(AstUtils.isJQueryExpression('S')).to.equal(false, 'Not jquery');
-        });
-    });
 });

--- a/src/tests/NoInnerHtmlRuleTests.ts
+++ b/src/tests/NoInnerHtmlRuleTests.ts
@@ -76,4 +76,16 @@ describe('noInnerHtmlRule', () : void => {
         ]);
     });
 
+    it('should pass on non-jQuery HTML method calls', () : void => {
+        const script : string = `
+            var myCustomObject = {
+              html: function (text) {
+                console.log('Called html with ' + text);
+              },
+            };
+            myCustomObject.html('here I am');
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
 });

--- a/src/tests/NoInnerHtmlRuleTests.ts
+++ b/src/tests/NoInnerHtmlRuleTests.ts
@@ -95,7 +95,7 @@ describe('noInnerHtmlRule', () : void => {
         beforeEach((): void => {
             options = [ true,
                 {
-                    'jquery-matcher': 'cheerio|[j|J][q|Q]uery'
+                    'html-lib-matcher': 'cheerio|[j|J][q|Q]uery'
                 }
             ];
         });

--- a/src/tests/NoInnerHtmlRuleTests.ts
+++ b/src/tests/NoInnerHtmlRuleTests.ts
@@ -88,4 +88,45 @@ describe('noInnerHtmlRule', () : void => {
 
         TestHelper.assertViolations(ruleName, script, [ ]);
     });
+
+    describe('with options', (): void => {
+        let options: any[];
+
+        beforeEach((): void => {
+            options = [ true,
+                {
+                    'jquery-matcher': 'cheerio|[j|J][q|Q]uery'
+                }
+            ];
+        });
+
+        it('should fail on invoking html(x) with different jQuery matcher', () : void => {
+            const script : string = `
+                cheerio(element).html('whatever');
+            `;
+
+            TestHelper.assertViolationsWithOptions(ruleName, options, script, [
+                {
+                    "failure": "Using the html() function to write a string to innerHTML is insecure: cheerio(element).html('whatever')",
+                    "name": "file.ts",
+                    "ruleName": "no-inner-html",
+                    "startPosition": { "character": 17, "line": 2 }
+                }
+            ]);
+        });
+
+      it('should pass on non-jQuery HTML method calls with options', () : void => {
+          const script : string = `
+              var myCustomObject = {
+                html: function (text) {
+                  console.log('Called html with ' + text);
+                },
+              };
+              myCustomObject.html('here I am');
+          `;
+
+          TestHelper.assertViolationsWithOptions(ruleName, options, script, [ ]);
+      });
+
+    });
 });

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -34,10 +34,6 @@ export module AstUtils {
         return functionTarget === '$' || /^(jquery)$/i.test(functionTarget);
     }
 
-    export function isJQueryExpression(functionTarget: string): boolean {
-        return /^(jquery|[$])/i.test(functionTarget);
-    }
-
     export function hasModifier(modifiers : ts.ModifiersArray, modifierKind : number) : boolean {
         if (modifiers == null) {
             return false;

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -34,6 +34,10 @@ export module AstUtils {
         return functionTarget === '$' || /^(jquery)$/i.test(functionTarget);
     }
 
+    export function isJQueryExpression(functionTarget: string): boolean {
+        return /^(jquery|[$])/i.test(functionTarget);
+    }
+
     export function hasModifier(modifiers : ts.ModifiersArray, modifierKind : number) : boolean {
         if (modifiers == null) {
             return false;


### PR DESCRIPTION
* Add unit tests for isJQuery method
* Add new method, `isJQueryExpression`, which returns true if the
  expression is a result of a jQuery function call or a function
  expression on a variable whose name starts with `$`, which is a common
  convention for identifying variables which are the result of a jQuery
  expression; add tests for it
* Modify `no-inner-html` to only flag method calls if the method
  invocant appears to be a jQuery expression

Resolves #425