### PR TITLE
export-name: detect export declarations

### DIFF
--- a/src/tests/ExportNameRuleTests.ts
+++ b/src/tests/ExportNameRuleTests.ts
@@ -138,6 +138,16 @@ describe('exportNameRule', () : void => {
             TestHelper.assertViolations(ruleName, script, [ ]);
         });
 
+        it('when single function is named same as the file exported in separate statement', () : void => {
+            // TestHelper assumes that all scripts are within file.ts
+            const script : string = `
+                function file() {};
+                export { file };
+            `;
+
+            TestHelper.assertViolations(ruleName, script, [ ]);
+        });
+
         it('when anonymous Object is exported', () : void => {
             // TestHelper assumes that all scripts are within file.ts
             const script : string = `

--- a/src/tests/ExportNameRuleTests.ts
+++ b/src/tests/ExportNameRuleTests.ts
@@ -315,6 +315,24 @@ describe('exportNameRule', () : void => {
             ]);
         });
 
+        it('when mis-named function is exported in a separate statement', () : void => {
+            // TestHelper assumes that all scripts are within file.ts
+            const script : string = `
+                function Example3a() {}
+                export { Example3a };
+            `;
+
+            TestHelper.assertViolations(ruleName, script, [
+                {
+                    "failure": "The exported module or identifier name must match the file name. Found: file.ts and Example3a",
+                    "name": "file.ts",
+                    "ruleName": "export-name",
+                    "startPosition": { "character": 17, "line": 3 }
+                }
+
+            ]);
+        });
+
         it('when mis-named let defined variable is exported', () : void => {
             // TestHelper assumes that all scripts are within file.ts
             const script : string = `


### PR DESCRIPTION
Previously, the `export-name` rule would detect an export assignment
like

```
export = Fish;
// or
export default Fish;
```

but it would not detect an export like

```
export { Fish }
```

Fixes #444 