### PR TITLE
Remove invalid examples.com domain from no-http-string

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -19,7 +19,7 @@ module.exports = {
         "no-eval": true,
         "no-exec-script": true,
         "no-function-constructor-with-string-args": true,
-        "no-http-string": [true, "http://www.example.com/?.*", "http://www.examples.com/?.*", "http://localhost:?.*"],
+        "no-http-string": [true, "http://www.example.com/?.*", "http://localhost:?.*"],
         "no-inner-html": true,
         "no-octal-literal": true,
         "no-reserved-keywords": true,


### PR DESCRIPTION
This follows-up a discussion at https://github.com/Microsoft/tslint-microsoft-contrib/pull/423.