### PR TITLE
Allow this.retries, this.slow, and this.timeout as side effects of Mocha tests

### DIFF
--- a/src/mochaNoSideEffectCodeRule.ts
+++ b/src/mochaNoSideEffectCodeRule.ts
@@ -156,6 +156,11 @@ class MochaNoSideEffectCodeRuleWalker extends ErrorTolerantWalker {
             });
             return;
         }
+        // From https://mochajs.org/, `this.retries(...)`, `this.slow(...)`, and
+        // `this.timeout(...)` are allowed outside tests
+        if (/^this\.(retries|slow|timeout)\(.+\)$/.test(initializer.getText())) {
+            return;
+        }
         // moment() is OK
         if (initializer.getText() === 'moment()') {
             return;

--- a/src/tests/MochaNoSideEffectCodeRuleTests.ts
+++ b/src/tests/MochaNoSideEffectCodeRuleTests.ts
@@ -241,6 +241,24 @@ describe('mochaNoSideEffectCodeRule', () : void => {
         TestHelper.assertViolations(ruleName, script, [ ]);
     });
 
+    it('should pass when using methods allowed by the Mocha API', () : void => {
+        const script : string = `
+            describe('retries', (): void => {
+                this.retries(42);
+
+                describe('slow', (): void => {
+                    this.slow(2500);
+
+                    describe('timeout', (): void => {
+                        this.timeout(5000);
+                    });
+                });
+            });
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
     it('should pass on date creation', () : void => {
         const script : string = `
             let date = moment();


### PR DESCRIPTION
Resolves https://github.com/Microsoft/tslint-microsoft-contrib/issues/446