### PR TITLE
Stricter regex to match only "describe" calls (#465)

### DIFF
--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -119,7 +119,7 @@ module.exports = {
         "jsdoc-format": true,
         "max-classes-per-file": [true, 3],  // we generally recommend making one public class per file
         "max-file-line-count": true,
-        "max-func-body-length": [true, 100, {"ignore-parameters-to-function-regex": "describe"}],
+        "max-func-body-length": [true, 100, {"ignore-parameters-to-function-regex": "^describe$"}],
         "max-line-length": [true, 140],
         "member-access": true,
         "member-ordering": [true, { "order": "fields-first" }],

--- a/src/maxFuncBodyLengthRule.ts
+++ b/src/maxFuncBodyLengthRule.ts
@@ -22,7 +22,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         severity: 'Moderate',
         level: 'Opportunity for Excellence',
         group: 'Clarity',
-        recommendation: '[true, 100, {"ignore-parameters-to-function-regex": "describe"}],',
+        recommendation: '[true, 100, {"ignore-parameters-to-function-regex": "^describe$"}],',
         commonWeaknessEnumeration: '398, 710'
     };
 

--- a/src/tests/MaxFuncBodyLengthRuleTests.ts
+++ b/src/tests/MaxFuncBodyLengthRuleTests.ts
@@ -285,7 +285,7 @@ describe('maxFuncBodyLengthRule', (): void => {
             options = [true,
                 5, // max length is now 5
                 {
-                    'ignore-parameters-to-function-regex': 'describe'
+                    'ignore-parameters-to-function-regex': '^describe$'
                 }
             ];
         });

--- a/src/tests/MaxFuncBodyLengthRuleTests.ts
+++ b/src/tests/MaxFuncBodyLengthRuleTests.ts
@@ -314,5 +314,31 @@ describe('maxFuncBodyLengthRule', (): void => {
             }); // line 7
             `, []);
         });
+
+        it('should not ignore calls of functions that are not exactly named "describe"', (): void => {
+            TestHelper.assertViolationsWithOptions(
+                ruleName,
+                options,
+                `
+                    describeThings('something', (): void => {
+                        // line 2
+                        // line 3
+                        // line 4
+                        // line 5
+                    }); // line 6
+                `, [
+                    {
+                        "failure": "Max arrow function body length exceeded - max: 5, actual: 6",
+                        "name": "file.ts",
+                        "ruleName": "max-func-body-length",
+                        "ruleSeverity": "ERROR",
+                        "startPosition": {
+                            "character": 49,
+                            "line": 2
+                        }
+                    }
+                ]
+            );
+        });
     });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -60,7 +60,7 @@
       true,
       100,
       {
-        "ignore-parameters-to-function-regex": "describe"
+        "ignore-parameters-to-function-regex": "^describe$"
       }
     ],
     "max-line-length": [


### PR DESCRIPTION
This PR intends to change the default option for max-func-body-length to avoid ignoring non-"describe" functions.
The PR also includes a corresponding test to verify that only "describe" is ignored.

I appreciate your attention and review!