### PR TITLE
Fix #437: Add undefined check before using toLowerCase

### DIFF
--- a/src/reactA11yImageButtonHasAltRule.ts
+++ b/src/reactA11yImageButtonHasAltRule.ts
@@ -59,6 +59,7 @@ class ReactA11yImageButtonHasAltWalker extends Lint.RuleWalker {
         if (!typeAttribute
             || typeAttribute.initializer === undefined
             || !isStringLiteral(typeAttribute.initializer)
+            || getStringLiteral(typeAttribute) === undefined
             || getStringLiteral(typeAttribute)!.toLowerCase() !== 'image') {
             return;
         }

--- a/src/tests/ReactA11yImageButtonHasAltRuleTests.ts
+++ b/src/tests/ReactA11yImageButtonHasAltRuleTests.ts
@@ -37,6 +37,16 @@ describe('reactA11yImageButtonHasAlt', (): void => {
 
             TestHelper.assertNoViolation(ruleName, script);
         });
+
+        it("when input element has an expression for its type thats undefined.", (): void => {
+            const script: string = `
+                import React = require('react');
+                const type = undefined;
+                const a = <input type={type} />;
+            `;
+
+            TestHelper.assertNoViolation(ruleName, script);
+        });
     });
 
     describe('should fail', (): void => {


### PR DESCRIPTION
Add `undefined` check before using `.toLowerCase()` on `getStringLiteral(typeAttribute)` to make the rule pass when the expression for the type of an input is `undefined`.

Fixes #437