### PR TITLE
Moved test linting overrides to their own tslint.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -235,14 +235,7 @@ module.exports = function(grunt) {
             },
             tests: {
                 options: {
-                    configuration: (function() {
-                        let tslintJson = grunt.file.readJSON("tslint.json", { encoding: 'UTF-8' });
-                        tslintJson.rules['quotemark'] = false;
-                        tslintJson.rules['object-literal-key-quotes'] = false;
-                        tslintJson.rules['max-func-body-length'] = false;
-                        tslintJson.rules['no-implicit-dependencies'] = [true, 'dev'];
-                        return tslintJson;
-                    })()
+                    configuration: grunt.file.readJSON("src/tests/tslint.json", { encoding: 'UTF-8' })
                 },
                 files: {
                     src: [

--- a/src/tests/tslint.json
+++ b/src/tests/tslint.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tslint.json",
+    "rules": {
+        "quotemark": false,
+        "object-literal-key-quotes": false,
+        "max-func-body-length": false,
+        "no-implicit-dependencies": [true, "dev"]
+    }
+}


### PR DESCRIPTION
VS Code's TSLint extension wasn't taking into account the overrides defined in `Gruntfile.js`. Moved those to their own `src/tests/tslint.json`.

Fixes #511
