### PR TITLE
Fix #525 - safe/consistent .tsx file type checks

### DIFF
--- a/src/noFunctionExpressionRule.ts
+++ b/src/noFunctionExpressionRule.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
+import { AstUtils } from './utils/AstUtils';
 import {ErrorTolerantWalker} from './utils/ErrorTolerantWalker';
 import {ExtendedMetadata} from './utils/ExtendedMetadata';
 
@@ -37,7 +38,8 @@ class NoFunctionExpressionRuleWalker extends ErrorTolerantWalker {
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
-        if (sourceFile.fileName.endsWith('tsx')) {
+
+        if (AstUtils.getLanguageVariant(sourceFile) === ts.LanguageVariant.JSX) {
             this.allowGenericFunctionExpression = true;
         }
     }

--- a/src/preferTypeCastRule.ts
+++ b/src/preferTypeCastRule.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
+import { AstUtils } from './utils/AstUtils';
 import {ErrorTolerantWalker} from './utils/ErrorTolerantWalker';
 import {ExtendedMetadata} from './utils/ExtendedMetadata';
 
@@ -34,7 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class PreferTypeCastRuleWalker extends ErrorTolerantWalker {
     protected visitSourceFile(node: ts.SourceFile): void {
-        if (/.*\.tsx/.test(node.fileName) === false) {
+        if (AstUtils.getLanguageVariant(node) === ts.LanguageVariant.Standard) {
             super.visitSourceFile(node);
         }
     }

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -6,7 +6,7 @@ import * as ts from 'typescript';
 export module AstUtils {
 
     export function getLanguageVariant(node: ts.SourceFile): ts.LanguageVariant {
-        if (/.*\.tsx/i.test(node.fileName)) {
+        if (node.fileName.endsWith('.tsx')) {
             return ts.LanguageVariant.JSX;
         } else {
             return ts.LanguageVariant.Standard;


### PR DESCRIPTION
These are the only instances of file extension checks like that I see. Changed them to all use the AstUtils helper. This is a behavior change for NoFunctionExpressionRuleWalker, `endsWith('tsx')` vs `endsWith('.tsx')` but I think this way is right.