### PR TITLE
AstUtils.getLanguageVariant() now accepts .jsx files and ignores case

### DIFF
--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -6,7 +6,8 @@ import * as ts from 'typescript';
 export module AstUtils {
 
     export function getLanguageVariant(node: ts.SourceFile): ts.LanguageVariant {
-        if (node.fileName.endsWith('.tsx')) {
+        const fileName: string = node.fileName.toLowerCase();
+        if (fileName.endsWith('.tsx') || fileName.endsWith('.jsx')) {
             return ts.LanguageVariant.JSX;
         } else {
             return ts.LanguageVariant.Standard;


### PR DESCRIPTION
I added the .jsx file extension to AstUtils.getLanguageVariant() as requested in issue #527
I also made it ignore the case of the extensions,
i think this behaviour was accidentaly removed in PR #526 