### PR TITLE
Fix #353: react-tsx-curly-spacing bug with comments

### DIFF
--- a/src/reactTsxCurlySpacingRule.ts
+++ b/src/reactTsxCurlySpacingRule.ts
@@ -52,12 +52,15 @@ class TsxCurlySpacingWalker extends Lint.RuleWalker {
 
     public visitJsxExpression(node: ts.JsxExpression): void {
         const childrenCount: number = node.getChildCount();
-        const first = node.getFirstToken(); // '{' sign
-        const last = node.getLastToken(); // '}' sign
-        const second: ts.Node = node.getChildAt(1); // after '{' sign
-        const penultimate: ts.Node = node.getChildAt(childrenCount - 2); // before '}' sign
-        this.validateBraceSpacing(node, first, second, first);
-        this.validateBraceSpacing(node, penultimate, last, last);
+
+        if (childrenCount > 2) {// not empty code block (eg. only comments)
+            const first = node.getFirstToken(); // '{' sign
+            const last = node.getLastToken(); // '}' sign
+            const second: ts.Node = node.getChildAt(1); // after '{' sign
+            const penultimate: ts.Node = node.getChildAt(childrenCount - 2); // before '}' sign
+            this.validateBraceSpacing(node, first, second, first);
+            this.validateBraceSpacing(node, penultimate, last, last);
+        }
     }
 
     protected visitNode(node: ts.Node): void {

--- a/src/tests/ReactTsxCurlySpacingRuleTests.ts
+++ b/src/tests/ReactTsxCurlySpacingRuleTests.ts
@@ -21,6 +21,7 @@ describe('reactTsxCurlySpacing', () => {
                 const script: string = `
                     import React = require('react');
                     const a = <Hello name={firstname} />;
+                    const b = <div>{/* comment */}</div>;
                 `;
                 TestHelper.assertViolationsWithOptions(ruleName, [ 'never' ], script, []);
             });


### PR DESCRIPTION
Bug caused by empty `{}`  node when it only contains comments

Fixes #353 