### PR TITLE
Fixed up simultaneous merges around Utils.absolutePath PR

### DIFF
--- a/src/tests/MochaNoSideEffectCodeRuleTests.ts
+++ b/src/tests/MochaNoSideEffectCodeRuleTests.ts
@@ -538,7 +538,7 @@ describe('mochaNoSideEffectCodeRule', () : void => {
                 {
                     "failure": "Mocha test contains dangerous variable initialization. " +
                             "Move to before()/beforeEach(): [ someCall() ].forEach((): v...",
-                    "name": "file.ts",
+                    "name": Utils.absolutePath("file.ts"),
                     "ruleName": "mocha-no-side-effect-code",
                     "startPosition": { "character": 21, "line": 3 }
                 }
@@ -559,7 +559,7 @@ describe('mochaNoSideEffectCodeRule', () : void => {
                 {
                     "failure": "Mocha test contains dangerous variable initialization. " +
                             "Move to before()/beforeEach(): someCall().forEach((): void ...",
-                    "name": "file.ts",
+                    "name": Utils.absolutePath("file.ts"),
                     "ruleName": "mocha-no-side-effect-code",
                     "startPosition": { "character": 21, "line": 3 }
                 }
@@ -581,7 +581,7 @@ describe('mochaNoSideEffectCodeRule', () : void => {
                 {
                     "failure": "Mocha test contains dangerous variable initialization. " +
                             "Move to before()/beforeEach(): VIOLATION = new MyClass()",
-                    "name": "file.ts",
+                    "name": Utils.absolutePath("file.ts"),
                     "ruleName": "mocha-no-side-effect-code",
                     "startPosition": { "character": 31, "line": 4 }
                 }

--- a/src/tests/ReactA11yAnchorsRuleTests.ts
+++ b/src/tests/ReactA11yAnchorsRuleTests.ts
@@ -562,7 +562,7 @@ describe('reactA11yAnchorsRule', () : void => {
             TestHelper.assertViolations(ruleName, script, [
                 {
                     "failure": ACCESSIBLE_HIDDEN_CONTENT_FAILURE_STRING,
-                    "name": "file.tsx",
+                    "name": Utils.absolutePath("file.tsx"),
                     "ruleName": "react-a11y-anchors",
                     "startPosition": { "character": 27, "line": 4 }
                 }

--- a/src/tests/ReactNoDangerousHtmlRuleTests.ts
+++ b/src/tests/ReactNoDangerousHtmlRuleTests.ts
@@ -1,63 +1,11 @@
 import {Utils} from '../utils/Utils';
 import {TestHelper} from './TestHelper';
-import {Rule} from '../reactNoDangerousHtmlRule';
-
-const dangerousScript : string = `
-class MyComponent {
-    public render() : ReactTypes.ReactElement<any> {
-        return React.createElement("div", {
-                dangerouslySetInnerHTML: {__html: this.props.text}
-            }
-        );
-    }
-}`;
 
 /**
  * Unit tests.
  */
 describe('reactNoDangerousHtmlRule', () : void => {
     const ruleName : string = 'react-no-dangerous-html';
-    const exceptions : {}[] = [];
-    let original: any;
-
-    beforeEach(() : void => {
-        original = Rule.getExceptions;
-        Rule.getExceptions = () : any => { return exceptions; };
-    });
-
-    afterEach(() : void => {
-        Rule.getExceptions = original;
-    });
-
-    it('should produce violation when function called with no suppression', () : void => {
-        exceptions.length = 0;
-        TestHelper.assertViolations(
-            ruleName,
-            dangerousScript,
-            [
-                {
-                    "failure": "Invalid call to dangerouslySetInnerHTML in method \"render\"\n" +
-                    "    of source file " + Utils.absolutePath("file.ts") + "\"\n    Do *NOT* add a suppression for this warning. " +
-                    "If you absolutely must use this API then you need\n    to review the usage with a " +
-                    "security expert/QE representative. If they decide that this is an\n    acceptable usage " +
-                    "then add the exception to xss_exceptions.json",
-                    "name": Utils.absolutePath("file.ts"),
-                    "ruleName": ruleName,
-                    "startPosition": { "character": 17, "line": 5 }
-                }
-            ]
-        );
-    });
-
-    it('should not produce violation when call exists in exception list', () : void => {
-        exceptions.push({ file: Utils.absolutePath('file.tsx'), method: 'render', comment: 'this usage is OK' });
-
-        TestHelper.assertViolations(
-            ruleName,
-            dangerousScript,
-            []
-        );
-    });
 
     it('should find violations in .tsx files', (): void => {
         TestHelper.assertViolations(

--- a/src/tests/ReactNoDangerousHtmlRuleTests.ts
+++ b/src/tests/ReactNoDangerousHtmlRuleTests.ts
@@ -50,7 +50,7 @@ describe('reactNoDangerousHtmlRule', () : void => {
     });
 
     it('should not produce violation when call exists in exception list', () : void => {
-        exceptions.push({ file: 'file.ts', method: 'render', comment: 'this usage is OK' });
+        exceptions.push({ file: Utils.absolutePath('file.tsx'), method: 'render', comment: 'this usage is OK' });
 
         TestHelper.assertViolations(
             ruleName,

--- a/src/tests/reactA11yImgHasAltRuleTests.ts
+++ b/src/tests/reactA11yImgHasAltRuleTests.ts
@@ -186,23 +186,23 @@ const c = <img alt={''} title='Some image' role='presentation' />;
           fileName,
           [
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 3 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('img')
             },
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 4 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('img')
             },
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 5 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('img')
-            },
+            }
           ]
         );
       });
@@ -261,23 +261,23 @@ const c = <Picture alt={''} title='Some image' role='presentation' />;
           fileName,
           [
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 5 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('Picture')
             },
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 6 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('Picture')
             },
             {
-              name: 'file.tsx',
+              name: Utils.absolutePath('file.tsx'),
               ruleName: ruleName,
               startPosition: { character: 11, line: 7 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('Picture')
-            },
+            }
           ]
         );
       });


### PR DESCRIPTION
Some PRs went in about the same time that didn't add the `Utils` helper in test files.

Fixes #561.