### PR TITLE
Used undefined instead of null.

### DIFF
--- a/additional_rule_metadata.json
+++ b/additional_rule_metadata.json
@@ -350,7 +350,7 @@
     "severity": "Important",
     "level": "Opportunity for Excellence",
     "group": "Clarity",
-    "recommendation": "false, // turn no-null-keyword off and use undefined to mean not initialized and null to mean without a value",
+    "recommendation": "true,",
     "commonWeaknessEnumeration": "710"
   },
   "no-reference": {

--- a/recommended_ruleset.js
+++ b/recommended_ruleset.js
@@ -138,7 +138,7 @@ module.exports = {
         "no-function-expression": true,
         "no-inferrable-types": false, // turn no-inferrable-types off in order to make the code consistent in its use of type decorations
         "no-multiline-string": false,
-        "no-null-keyword": false, // turn no-null-keyword off and use undefined to mean not initialized and null to mean without a value
+        "no-null-keyword": true,
         "no-parameter-properties": true,
         "no-redundant-jsdoc": true,
         "no-relative-imports": true,

--- a/src/chaiPreferContainsToIndexOfRule.ts
+++ b/src/chaiPreferContainsToIndexOfRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'chai-prefer-contains-to-index-of',
         type: 'maintainability',
         description: 'Avoid Chai assertions that invoke indexOf and compare for a -1 result.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/chaiPreferContainsToIndexOfRule.ts
+++ b/src/chaiPreferContainsToIndexOfRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'chai-prefer-contains-to-index-of',
         type: 'maintainability',
         description: 'Avoid Chai assertions that invoke indexOf and compare for a -1 result.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -51,7 +51,7 @@ class ChaiPreferContainsToIndexOfRuleWalker extends ErrorTolerantWalker {
     }
 
     private isFirstArgumentNegative1(node: ts.CallExpression): boolean {
-        if (node.arguments != null && node.arguments.length > 0) {
+        if (node.arguments !== undefined && node.arguments.length > 0) {
             const firstArgument: ts.Expression = node.arguments[0];
             if (firstArgument.getText() === '-1') {
                 return true;
@@ -62,7 +62,7 @@ class ChaiPreferContainsToIndexOfRuleWalker extends ErrorTolerantWalker {
 
     private isFirstArgumentIndexOfResult(node: ts.CallExpression): boolean {
         const expectCall = ChaiUtils.getLeftMostCallExpression(node);
-        if (expectCall !== null && expectCall.arguments != null && expectCall.arguments.length > 0) {
+        if (expectCall !== undefined && expectCall.arguments !== undefined && expectCall.arguments.length > 0) {
             const firstArgument: ts.Expression = expectCall.arguments[0];
             if (firstArgument.kind === ts.SyntaxKind.CallExpression) {
                 if (AstUtils.getFunctionName(<ts.CallExpression>firstArgument) === 'indexOf') {

--- a/src/chaiVagueErrorsRule.ts
+++ b/src/chaiVagueErrorsRule.ts
@@ -21,7 +21,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'chai-vague-errors',
         type: 'maintainability',
         description: 'Avoid Chai assertions that result in vague errors',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -63,9 +63,9 @@ class ChaiVagueErrorsRuleWalker extends ErrorTolerantWalker {
             }
 
             const actualValue = ChaiUtils.getFirstExpectCallParameter(node);
-            if (actualValue !== null && actualValue.kind === ts.SyntaxKind.BinaryExpression) {
+            if (actualValue !== undefined && actualValue.kind === ts.SyntaxKind.BinaryExpression) {
                 const expectedValue = ChaiUtils.getFirstExpectationParameter(node);
-                if (expectedValue !== null) {
+                if (expectedValue !== undefined) {
                     const binaryExpression: ts.BinaryExpression = <ts.BinaryExpression>actualValue;
                     const operator: string = binaryExpression.operatorToken.getText();
                     const expectingBooleanKeyword: boolean = expectedValue.kind === ts.SyntaxKind.TrueKeyword

--- a/src/chaiVagueErrorsRule.ts
+++ b/src/chaiVagueErrorsRule.ts
@@ -21,7 +21,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'chai-vague-errors',
         type: 'maintainability',
         description: 'Avoid Chai assertions that result in vague errors',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/exportNameRule.ts
+++ b/src/exportNameRule.ts
@@ -58,7 +58,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     /* tslint:disable:function-name */
-    public static getExceptions(options : Lint.IOptions): string[] | null {
+    public static getExceptions(options : Lint.IOptions): string[] | undefined {
     /* tslint:enable:function-name */
         if (options.ruleArguments instanceof Array) {
             return options.ruleArguments[0];
@@ -68,7 +68,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 options[0].allow :
                 <string[]><any>options; // MSE version of tslint somehow requires this
         }
-        return null;
+        return undefined;
     }
 
     /* tslint:disable:function-name */
@@ -133,7 +133,7 @@ export class ExportNameWalker extends ErrorTolerantWalker {
         this.validateExportedElements(exportedTopLevelElements);
     }
 
-    private getExportStatementsWithinModules(moduleDeclaration: ts.ModuleDeclaration): ts.Statement[] | null {
+    private getExportStatementsWithinModules(moduleDeclaration: ts.ModuleDeclaration): ts.Statement[] | undefined {
         if (moduleDeclaration.body!.kind === ts.SyntaxKind.ModuleDeclaration) {
             // modules may be nested so recur into the structure
             return this.getExportStatementsWithinModules(<ts.ModuleDeclaration>moduleDeclaration.body);
@@ -141,7 +141,7 @@ export class ExportNameWalker extends ErrorTolerantWalker {
             const moduleBlock: ts.ModuleBlock = <ts.ModuleBlock>moduleDeclaration.body;
             return moduleBlock.statements.filter(isExportedDeclaration);
         }
-        return null;
+        return undefined;
     }
 
     private validateExportedElements(exportedElements: ts.Statement[]): void {

--- a/src/functionNameRule.ts
+++ b/src/functionNameRule.ts
@@ -143,7 +143,7 @@ class FunctionNameRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitFunctionDeclaration(node: ts.FunctionDeclaration): void {
-        if (node.name != null) {
+        if (node.name !== undefined) {
             const name: string = node.name.text;
             if (!this.functionRegex.test(name)) {
                 this.addFailureAt(node.name.getStart(), node.name.getWidth(),
@@ -155,7 +155,7 @@ class FunctionNameRuleWalker extends ErrorTolerantWalker {
 
     private getOptionOrDefault(option: any, key: string, defaultValue: RegExp): RegExp {
         try {
-            if (option[key] != null) {
+            if (option[key] !== undefined) {
                 return new RegExp(option[key]);
             }
         } catch (e) {

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'The name of the imported module must match the name of the thing being imported',
         hasFix: true,
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'The name of the imported module must match the name of the thing being imported',
         hasFix: true,
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -73,7 +73,7 @@ class ImportNameRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitImportDeclaration(node: ts.ImportDeclaration): void {
-        if (node.importClause!.name != null) {
+        if (node.importClause!.name !== undefined) {
             const name: string = node.importClause!.name!.text;
             if (node.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral) {
                 const moduleName: string = (<ts.StringLiteral>node.moduleSpecifier).text;

--- a/src/insecureRandomRule.ts
+++ b/src/insecureRandomRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'insecure-random',
         type: 'functionality',
         description: 'Do not use insecure sources for random bytes',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/insecureRandomRule.ts
+++ b/src/insecureRandomRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'insecure-random',
         type: 'functionality',
         description: 'Do not use insecure sources for random bytes',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/jqueryDeferredMustCompleteRule.ts
+++ b/src/jqueryDeferredMustCompleteRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'When a JQuery Deferred instance is created, then either reject() or resolve() must be called ' +
                     'on it within all code branches in the scope.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -36,11 +36,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function isPromiseInstantiation(expression: ts.Expression) : boolean {
-    if (expression != null && expression.kind === ts.SyntaxKind.CallExpression) {
+    if (expression !== undefined && expression.kind === ts.SyntaxKind.CallExpression) {
         const functionName = AstUtils.getFunctionName(<ts.CallExpression>expression);
         const functionTarget = AstUtils.getFunctionTarget(<ts.CallExpression>expression);
 
-        if (functionName === 'Deferred' && functionTarget !== null && AstUtils.isJQuery(functionTarget)) {
+        if (functionName === 'Deferred' && functionTarget !== undefined && AstUtils.isJQuery(functionTarget)) {
             return true;
         }
     }
@@ -55,7 +55,7 @@ class JQueryDeferredAnalyzer extends ErrorTolerantWalker {
     protected visitBinaryExpression(node: ts.BinaryExpression): void {
         if (node.operatorToken.getText() === '=' && isPromiseInstantiation(node.right)) {
             if (node.left.kind === ts.SyntaxKind.Identifier) {
-                if ((<ts.Identifier>node.left).text != null) {
+                if ((<ts.Identifier>node.left).text !== undefined) {
                     const name : ts.Identifier = <ts.Identifier>node.left;
                     this.validateDeferredUsage(node, name);
                 }
@@ -66,7 +66,7 @@ class JQueryDeferredAnalyzer extends ErrorTolerantWalker {
 
     protected visitVariableDeclaration(node: ts.VariableDeclaration): void {
         if (node.initializer !== undefined && isPromiseInstantiation(node.initializer)) {
-            if ((<ts.Identifier>node.name).text != null) {
+            if ((<ts.Identifier>node.name).text !== undefined) {
                 const name : ts.Identifier = <ts.Identifier>node.name;
                 this.validateDeferredUsage(node, name);
             }
@@ -127,7 +127,7 @@ class DeferredCompletionWalker extends ErrorTolerantWalker {
 
         if (!ifAnalyzer.isAlwaysCompleted()) {
             this.allBranchesCompleted = false;
-        } else if (node.elseStatement != null) {
+        } else if (node.elseStatement !== undefined) {
             elseAnalyzer.visitNode(node.elseStatement);
             if (!elseAnalyzer.isAlwaysCompleted()) {
                 this.allBranchesCompleted = false;

--- a/src/jqueryDeferredMustCompleteRule.ts
+++ b/src/jqueryDeferredMustCompleteRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'When a JQuery Deferred instance is created, then either reject() or resolve() must be called ' +
                     'on it within all code branches in the scope.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/maxFuncBodyLengthRule.ts
+++ b/src/maxFuncBodyLengthRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'max-func-body-length',
         type: 'maintainability',
         description: 'Avoid long functions.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/maxFuncBodyLengthRule.ts
+++ b/src/maxFuncBodyLengthRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'max-func-body-length',
         type: 'maintainability',
         description: 'Avoid long functions.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -115,7 +115,7 @@ class MaxFunctionBodyLengthRuleWalker extends Lint.RuleWalker {
     }
 
     private calcBodyLength(node: ts.FunctionLikeDeclaration) {
-        if (node.body == null) {
+        if (node.body === undefined) {
             return 0;
         }
         const sourceFile: ts.SourceFile = this.getSourceFile();

--- a/src/missingJsdocRule.ts
+++ b/src/missingJsdocRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'missing-jsdoc',
         type: 'maintainability',
         description: 'All files must have a top level JSDoc comment.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/missingJsdocRule.ts
+++ b/src/missingJsdocRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'missing-jsdoc',
         type: 'maintainability',
         description: 'All files must have a top level JSDoc comment.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/missingOptionalAnnotationRule.ts
+++ b/src/missingOptionalAnnotationRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'missing-optional-annotation',
         type: 'maintainability',
         description: 'Deprecated - This rule is now enforced by the TypeScript compiler',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/missingOptionalAnnotationRule.ts
+++ b/src/missingOptionalAnnotationRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'missing-optional-annotation',
         type: 'maintainability',
         description: 'Deprecated - This rule is now enforced by the TypeScript compiler',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -59,13 +59,13 @@ class MissingOptionalAnnotationWalker extends ErrorTolerantWalker {
 
     private validateParameters(node : ts.SignatureDeclaration) {
         let optionalParameterFound = false;
-        if (node.parameters == null) {
+        if (node.parameters === undefined) {
             return;
         }
         node.parameters.forEach((parameter : ts.ParameterDeclaration) : void => {
-            if (parameter.questionToken != null || parameter.initializer != null) {
+            if (parameter.questionToken !== undefined || parameter.initializer !== undefined) {
                 optionalParameterFound = true;
-            } else if (optionalParameterFound && parameter.initializer == null) {
+            } else if (optionalParameterFound && parameter.initializer === undefined) {
                 // we found a non-optional parameter that comes *after* an optional parameter
                 const msg = Rule.FAILURE_STRING + parameter.getFullText();
                 this.addFailureAt(parameter.name.getStart(), parameter.name.getWidth(), msg);

--- a/src/mochaAvoidOnlyRule.ts
+++ b/src/mochaAvoidOnlyRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-avoid-only',
         type: 'maintainability',
         description: 'Do not invoke Mocha\'s describe.only, it.only or context.only functions.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/mochaAvoidOnlyRule.ts
+++ b/src/mochaAvoidOnlyRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-avoid-only',
         type: 'maintainability',
         description: 'Do not invoke Mocha\'s describe.only, it.only or context.only functions.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/mochaNoSideEffectCodeRule.ts
+++ b/src/mochaNoSideEffectCodeRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-no-side-effect-code',
         type: 'maintainability',
         description: 'All test logic in a Mocha test case should be within Mocha lifecycle method.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/mochaNoSideEffectCodeRule.ts
+++ b/src/mochaNoSideEffectCodeRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-no-side-effect-code',
         type: 'maintainability',
         description: 'All test logic in a Mocha test case should be within Mocha lifecycle method.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -46,7 +46,7 @@ class MochaNoSideEffectCodeRuleWalker extends ErrorTolerantWalker {
     private parseOptions() {
         this.getOptions().forEach((opt: any) => {
             if (typeof(opt) === 'object') {
-                if (opt.ignore != null) {
+                if (opt.ignore !== undefined) {
                     this.ignoreRegex = new RegExp(opt.ignore);
                 }
             }
@@ -108,7 +108,7 @@ class MochaNoSideEffectCodeRuleWalker extends ErrorTolerantWalker {
     }
 
     private validateExpression(initializer: ts.Expression, parentNode: ts.Node): void {
-        if (initializer == null) {
+        if (initializer === undefined) {
             return;
         }
         // constants cannot throw errors in the test runner
@@ -196,7 +196,7 @@ class MochaNoSideEffectCodeRuleWalker extends ErrorTolerantWalker {
             }
         }
         // ignore anything matching our ignore regex
-        if (this.ignoreRegex != null && this.ignoreRegex.test(initializer.getText())) {
+        if (this.ignoreRegex !== undefined && this.ignoreRegex.test(initializer.getText())) {
             return;
         }
 

--- a/src/mochaUnneededDoneRule.ts
+++ b/src/mochaUnneededDoneRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-unneeded-done',
         type: 'maintainability',
         description: 'A function declares a MochaDone parameter but only resolves it synchronously in the main function.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -52,7 +52,7 @@ class MochaUnneededDoneRuleWalker extends ErrorTolerantWalker {
 
     private validateMochaDoneUsage(node: ts.FunctionLikeDeclaration): void {
         const doneIdentifier = this.maybeGetMochaDoneParameter(node);
-        if (doneIdentifier == null) {
+        if (doneIdentifier === undefined) {
             return;
         }
         if (!this.isIdentifierInvokedDirectlyInBody(doneIdentifier, node)) {
@@ -69,7 +69,7 @@ class MochaUnneededDoneRuleWalker extends ErrorTolerantWalker {
     }
 
     private isIdentifierInvokedDirectlyInBody(doneIdentifier: ts.Identifier, node: ts.FunctionLikeDeclaration): boolean {
-        if (node.body == null || node.body.kind !== ts.SyntaxKind.Block) {
+        if (node.body === undefined || node.body.kind !== ts.SyntaxKind.Block) {
             return false;
         }
         const block: ts.Block = <ts.Block>node.body;
@@ -86,19 +86,19 @@ class MochaUnneededDoneRuleWalker extends ErrorTolerantWalker {
         });
     }
 
-    private maybeGetMochaDoneParameter(node: ts.FunctionLikeDeclaration): ts.Identifier | null {
+    private maybeGetMochaDoneParameter(node: ts.FunctionLikeDeclaration): ts.Identifier | undefined {
         if (node.parameters.length === 0) {
-            return null;
+            return undefined;
         }
         const allDones: ts.ParameterDeclaration[] = node.parameters.filter((parameter: ts.ParameterDeclaration): boolean => {
-            if (parameter.type != null && parameter.type.getText() === 'MochaDone') {
+            if (parameter.type !== undefined && parameter.type.getText() === 'MochaDone') {
                 return true;
             }
             return parameter.name.getText() === 'done';
         });
 
         if (allDones.length === 0 || allDones[0].name.kind !== ts.SyntaxKind.Identifier) {
-            return null;
+            return undefined;
         }
         return <ts.Identifier>allDones[0].name;
     }

--- a/src/mochaUnneededDoneRule.ts
+++ b/src/mochaUnneededDoneRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'mocha-unneeded-done',
         type: 'maintainability',
         description: 'A function declares a MochaDone parameter but only resolves it synchronously in the main function.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noBackboneGetSetOutsideModelRule.ts
+++ b/src/noBackboneGetSetOutsideModelRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-backbone-get-set-outside-model',
         type: 'maintainability',
         description: 'Avoid using `model.get(\'x\')` and `model.set(\'x\', value)` Backbone accessors outside of the owning model.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noBackboneGetSetOutsideModelRule.ts
+++ b/src/noBackboneGetSetOutsideModelRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-backbone-get-set-outside-model',
         type: 'maintainability',
         description: 'Avoid using `model.get(\'x\')` and `model.set(\'x\', value)` Backbone accessors outside of the owning model.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noBannedTermsRule.ts
+++ b/src/noBannedTermsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-banned-terms',
         type: 'maintainability',
         description: 'Do not use banned terms: caller, callee, eval, arguments.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noBannedTermsRule.ts
+++ b/src/noBannedTermsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-banned-terms',
         type: 'maintainability',
         description: 'Do not use banned terms: caller, callee, eval, arguments.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noConstantConditionRule.ts
+++ b/src/noConstantConditionRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-constant-condition',
         type: 'maintainability',
         description: 'Do not use constant expressions in conditions.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noConstantConditionRule.ts
+++ b/src/noConstantConditionRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-constant-condition',
         type: 'maintainability',
         description: 'Do not use constant expressions in conditions.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -90,7 +90,7 @@ class NoConstantConditionRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitForStatement(node: ts.ForStatement): void {
-        if (this.checkLoops && node.condition != null) {
+        if (this.checkLoops && node.condition !== undefined) {
             if (AstUtils.isConstantExpression(node.condition)) {
                 const message: string = Rule.FAILURE_STRING + ';' + node.condition.getText() + ';';
                 this.addFailureAt(node.getStart(), node.getWidth(), message);

--- a/src/noControlRegexRule.ts
+++ b/src/noControlRegexRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-control-regex',
         type: 'maintainability',
         description: 'Do not use control characters in regular expressions',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noControlRegexRule.ts
+++ b/src/noControlRegexRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-control-regex',
         type: 'maintainability',
         description: 'Do not use control characters in regular expressions',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noCookiesRule.ts
+++ b/src/noCookiesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.TypedRule {
         ruleName: 'no-cookies',
         type: 'maintainability',
         description: 'Do not use cookies',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noCookiesRule.ts
+++ b/src/noCookiesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.TypedRule {
         ruleName: 'no-cookies',
         type: 'maintainability',
         description: 'Do not use cookies',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDeleteExpressionRule.ts
+++ b/src/noDeleteExpressionRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-delete-expression',
         type: 'maintainability',
         description: 'Do not delete expressions. Only properties should be deleted',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -38,7 +38,7 @@ class NoDeleteExpression extends ErrorTolerantWalker {
         if (node.expression.kind === ts.SyntaxKind.DeleteExpression) {
             // first child is delete keyword, second one is what is being deleted.
             const deletedObject: ts.Node = node.expression.getChildren()[1];
-            if (deletedObject != null && deletedObject.kind === ts.SyntaxKind.Identifier) {
+            if (deletedObject !== undefined && deletedObject.kind === ts.SyntaxKind.Identifier) {
                 this.addNoDeleteFailure(deletedObject);
             }
         }

--- a/src/noDeleteExpressionRule.ts
+++ b/src/noDeleteExpressionRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-delete-expression',
         type: 'maintainability',
         description: 'Do not delete expressions. Only properties should be deleted',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDisableAutoSanitizationRule.ts
+++ b/src/noDisableAutoSanitizationRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-disable-auto-sanitization',
         type: 'maintainability',
         description: 'Do not disable auto-sanitization of HTML because this opens up your page to an XSS attack. ',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDisableAutoSanitizationRule.ts
+++ b/src/noDisableAutoSanitizationRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-disable-auto-sanitization',
         type: 'maintainability',
         description: 'Do not disable auto-sanitization of HTML because this opens up your page to an XSS attack. ',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDocumentDomainRule.ts
+++ b/src/noDocumentDomainRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Do not write to document.domain. Scripts setting document.domain to any value should be ' +
                     'validated to ensure that the value is on a list of allowed sites.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDocumentDomainRule.ts
+++ b/src/noDocumentDomainRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Do not write to document.domain. Scripts setting document.domain to any value should be ' +
                     'validated to ensure that the value is on a list of allowed sites.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDocumentWriteRule.ts
+++ b/src/noDocumentWriteRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-document-write',
         type: 'maintainability',
         description: 'Do not use document.write',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDocumentWriteRule.ts
+++ b/src/noDocumentWriteRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-document-write',
         type: 'maintainability',
         description: 'Do not use document.write',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noDuplicateCaseRule.ts
+++ b/src/noDuplicateCaseRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-duplicate-case',
         type: 'maintainability',
         description: 'Do not use duplicate case labels in switch statements.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -46,7 +46,7 @@ class NoDuplicateCaseRuleWalker extends ErrorTolerantWalker {
         node.caseBlock.clauses.forEach((clauseOrDefault: ts.CaseOrDefaultClause): void => {
             if (clauseOrDefault.kind === ts.SyntaxKind.CaseClause) {
                 const clause: ts.CaseClause = <ts.CaseClause>clauseOrDefault;
-                if (clause.expression != null) {
+                if (clause.expression !== undefined) {
                     const caseText = clause.expression.getText();
                     if (seenLabels.indexOf(caseText) > -1) {
                         this.addFailureAt(clause.getStart(), clause.getWidth(), Rule.FAILURE_STRING + caseText);

--- a/src/noDuplicateCaseRule.ts
+++ b/src/noDuplicateCaseRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-duplicate-case',
         type: 'maintainability',
         description: 'Do not use duplicate case labels in switch statements.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noDuplicateParameterNamesRule.ts
+++ b/src/noDuplicateParameterNamesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-duplicate-parameter-names',
         type: 'maintainability',
         description: 'Deprecated - This rule is now enforced by the TypeScript compiler',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noDuplicateParameterNamesRule.ts
+++ b/src/noDuplicateParameterNamesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-duplicate-parameter-names',
         type: 'maintainability',
         description: 'Deprecated - This rule is now enforced by the TypeScript compiler',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -61,7 +61,7 @@ class NoDuplicateParameterNamesWalker extends ErrorTolerantWalker {
         const seenNames : {[index: string]: boolean} = {};
         node.parameters.forEach((parameter : ts.ParameterDeclaration) : void => {
             const parameterName : string = (<any>parameter.name).text;  // how does one check if the union type is Identifier?
-            if (parameterName != null) {
+            if (parameterName !== undefined) {
                 if (seenNames[parameterName]) {
                     this.addFailureAt(
                         parameter.name.getStart(), parameterName.length, Rule.FAILURE_STRING + '\'' + parameterName + '\'');

--- a/src/noEmptyInterfacesRule.ts
+++ b/src/noEmptyInterfacesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-empty-interfaces',
         type: 'maintainability',
         description: 'Do not use empty interfaces.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -51,11 +51,11 @@ class NoEmptyInterfacesRuleWalker extends ErrorTolerantWalker {
     }
 
     private isInterfaceEmpty(node: ts.InterfaceDeclaration): boolean {
-        return node.members == null || node.members.length === 0;
+        return node.members === undefined || node.members.length === 0;
     }
 
     private hasMultipleParents(node: ts.InterfaceDeclaration): boolean {
-        if (node.heritageClauses == null || node.heritageClauses.length === 0) {
+        if (node.heritageClauses === undefined || node.heritageClauses.length === 0) {
             return false;
         }
         return node.heritageClauses[0].types.length >= 2;

--- a/src/noEmptyInterfacesRule.ts
+++ b/src/noEmptyInterfacesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-empty-interfaces',
         type: 'maintainability',
         description: 'Do not use empty interfaces.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noEmptyLineAfterOpeningBraceRule.ts
+++ b/src/noEmptyLineAfterOpeningBraceRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-empty-line-after-opening-brace',
         type: 'maintainability',
         description: 'Avoid an empty line after an opening brace',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noEmptyLineAfterOpeningBraceRule.ts
+++ b/src/noEmptyLineAfterOpeningBraceRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-empty-line-after-opening-brace',
         type: 'maintainability',
         description: 'Avoid an empty line after an opening brace',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noExecScriptRule.ts
+++ b/src/noExecScriptRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-exec-script',
         type: 'maintainability',
         description: 'Do not use the execScript functions',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noExecScriptRule.ts
+++ b/src/noExecScriptRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-exec-script',
         type: 'maintainability',
         description: 'Do not use the execScript functions',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noForInRule.ts
+++ b/src/noForInRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-for-in',
         type: 'maintainability',
         description: 'Avoid use of for-in statements. They can be replaced by Object.keys',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noForInRule.ts
+++ b/src/noForInRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-for-in',
         type: 'maintainability',
         description: 'Avoid use of for-in statements. They can be replaced by Object.keys',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noFunctionConstructorWithStringArgsRule.ts
+++ b/src/noFunctionConstructorWithStringArgsRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-function-constructor-with-string-args',
         type: 'maintainability',
         description: 'Do not use the version of the Function constructor that accepts a string argument to define the body of the function',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noFunctionConstructorWithStringArgsRule.ts
+++ b/src/noFunctionConstructorWithStringArgsRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-function-constructor-with-string-args',
         type: 'maintainability',
         description: 'Do not use the version of the Function constructor that accepts a string argument to define the body of the function',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noFunctionExpressionRule.ts
+++ b/src/noFunctionExpressionRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-function-expression',
         type: 'maintainability',
         description: 'Do not use function expressions; use arrow functions (lambdas) instead.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noFunctionExpressionRule.ts
+++ b/src/noFunctionExpressionRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-function-expression',
         type: 'maintainability',
         description: 'Do not use function expressions; use arrow functions (lambdas) instead.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noHttpStringRule.ts
+++ b/src/noHttpStringRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         /* tslint:disable:no-http-string */
         description: 'Do not use strings that start with \'http:\'. URL strings should start with \'https:\'. ',
         /* tslint:enable:no-http-string */
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -69,13 +69,13 @@ class NoHttpStringWalker extends ErrorTolerantWalker {
         });
     }
 
-    private static getExceptions(options: Lint.IOptions): string[] | null {
+    private static getExceptions(options: Lint.IOptions): string[] | undefined {
         if (options.ruleArguments instanceof Array) {
             return options.ruleArguments[0];
         }
         if (options instanceof Array) {
             return <string[]><any>options; // MSE version of tslint somehow requires this
         }
-        return null;
+        return undefined;
     }
 }

--- a/src/noHttpStringRule.ts
+++ b/src/noHttpStringRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         /* tslint:disable:no-http-string */
         description: 'Do not use strings that start with \'http:\'. URL strings should start with \'https:\'. ',
         /* tslint:enable:no-http-string */
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noIncrementDecrementRule.ts
+++ b/src/noIncrementDecrementRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-increment-decrement',
         type: 'maintainability',
         description: 'Avoid use of increment and decrement operators particularly as part of complicated expressions',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noIncrementDecrementRule.ts
+++ b/src/noIncrementDecrementRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-increment-decrement',
         type: 'maintainability',
         description: 'Avoid use of increment and decrement operators particularly as part of complicated expressions',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noInnerHtmlRule.ts
+++ b/src/noInnerHtmlRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-inner-html',
         type: 'maintainability',
         description: 'Do not write values to innerHTML, outerHTML, or set HTML using the JQuery html() function.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noInnerHtmlRule.ts
+++ b/src/noInnerHtmlRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-inner-html',
         type: 'maintainability',
         description: 'Do not write values to innerHTML, outerHTML, or set HTML using the JQuery html() function.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -68,7 +68,7 @@ class NoInnerHtmlRuleWalker extends ErrorTolerantWalker {
         if (functionName === 'html') {
             if (node.arguments.length > 0) {
                 const functionTarget = AstUtils.getFunctionTarget(node);
-                if (functionTarget !== null && this.htmlLibExpressionRegex.test(functionTarget)) {
+                if (functionTarget !== undefined && this.htmlLibExpressionRegex.test(functionTarget)) {
                     this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_HTML_LIB + node.getText());
                 }
             }

--- a/src/noInvalidRegexpRule.ts
+++ b/src/noInvalidRegexpRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-invalid-regexp',
         type: 'maintainability',
         description: 'Do not use invalid regular expression strings in the RegExp constructor.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noInvalidRegexpRule.ts
+++ b/src/noInvalidRegexpRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-invalid-regexp',
         type: 'maintainability',
         description: 'Do not use invalid regular expression strings in the RegExp constructor.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noJqueryRawElementsRule.ts
+++ b/src/noJqueryRawElementsRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-jquery-raw-elements',
         type: 'maintainability',
         description: 'Do not create HTML elements using JQuery and string concatenation. It is error prone and can hide subtle defects.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -70,7 +70,7 @@ class NoJqueryRawElementsRuleWalker extends Lint.RuleWalker {
         }
 
         const match = text.match(/^<[A-Za-z]+\s*>(.*)<\/[A-Za-z]+\s*>$/m);
-        if (match != null && match[1] != null) {
+        if (match !== null && match[1] !== undefined) {
             const enclosedContent: string = match[1]; // get the stuff inside the tag
             if (enclosedContent.indexOf('<') === -1 && enclosedContent.indexOf('>') === -1) {
                 return false; // enclosed content looks like it contains no html elements

--- a/src/noJqueryRawElementsRule.ts
+++ b/src/noJqueryRawElementsRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-jquery-raw-elements',
         type: 'maintainability',
         description: 'Do not create HTML elements using JQuery and string concatenation. It is error prone and can hide subtle defects.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noMissingVisibilityModifiersRule.ts
+++ b/src/noMissingVisibilityModifiersRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-missing-visibility-modifiers',
         type: 'maintainability',
         description: 'Deprecated - This rule is in the TSLint product as `member-access`',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noMissingVisibilityModifiersRule.ts
+++ b/src/noMissingVisibilityModifiersRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-missing-visibility-modifiers',
         type: 'maintainability',
         description: 'Deprecated - This rule is in the TSLint product as `member-access`',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noMultilineStringRule.ts
+++ b/src/noMultilineStringRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-multiline-string',
         type: 'maintainability',
         description: 'Do not declare multiline strings',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noMultilineStringRule.ts
+++ b/src/noMultilineStringRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-multiline-string',
         type: 'maintainability',
         description: 'Do not declare multiline strings',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noMultipleVarDeclRule.ts
+++ b/src/noMultipleVarDeclRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-multiple-var-decl',
         type: 'maintainability',
         description: 'Deprecated - This rule is now part of the base TSLint product as the rule named \'one-variable-per-declaration\'',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noMultipleVarDeclRule.ts
+++ b/src/noMultipleVarDeclRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-multiple-var-decl',
         type: 'maintainability',
         description: 'Deprecated - This rule is now part of the base TSLint product as the rule named \'one-variable-per-declaration\'',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noOctalLiteralRule.ts
+++ b/src/noOctalLiteralRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-octal-literal',
         type: 'maintainability',
         description: 'Do not use octal literals or escaped octal sequences',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noOctalLiteralRule.ts
+++ b/src/noOctalLiteralRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-octal-literal',
         type: 'maintainability',
         description: 'Do not use octal literals or escaped octal sequences',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noRegexSpacesRule.ts
+++ b/src/noRegexSpacesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-regex-spaces',
         type: 'maintainability',
         description: 'Do not use multiple spaces in a regular expression literal. Similar to the ESLint no-regex-spaces rule',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noRegexSpacesRule.ts
+++ b/src/noRegexSpacesRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-regex-spaces',
         type: 'maintainability',
         description: 'Do not use multiple spaces in a regular expression literal. Similar to the ESLint no-regex-spaces rule',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -34,7 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoRegexSpacesRuleWalker extends ErrorTolerantWalker {
     protected visitRegularExpressionLiteral(node: ts.Node): void {
         const match = /( {2,})+?/.exec(node.getText());
-        if (match != null) {
+        if (match !== null) {
             const replacement: string = '{' + match[0].length + '}';
             this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING + replacement);
         }

--- a/src/noReservedKeywordsRule.ts
+++ b/src/noReservedKeywordsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-reserved-keywords',
         type: 'maintainability',
         description: 'Do not use reserved keywords as names of local variables, fields, functions, or other identifiers.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noReservedKeywordsRule.ts
+++ b/src/noReservedKeywordsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-reserved-keywords',
         type: 'maintainability',
         description: 'Do not use reserved keywords as names of local variables, fields, functions, or other identifiers.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noSingleLineBlockCommentRule.ts
+++ b/src/noSingleLineBlockCommentRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-single-line-block-comment',
         type: 'maintainability',
         description: 'Avoid single line block comments; use single line comments instead',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noSingleLineBlockCommentRule.ts
+++ b/src/noSingleLineBlockCommentRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-single-line-block-comment',
         type: 'maintainability',
         description: 'Avoid single line block comments; use single line comments instead',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noStatelessClassRule.ts
+++ b/src/noStatelessClassRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-stateless-class',
         type: 'maintainability',
         description: 'A stateless class represents a failure in the object oriented design of the system.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -43,7 +43,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoStatelessClassRuleWalker extends ErrorTolerantWalker {
     protected visitClassDeclaration(node: ts.ClassDeclaration): void {
         if (!this.isClassStateful(node)) {
-            const className: string = node.name == null ? '<unknown>' : node.name.text;
+            const className: string = node.name === undefined ? '<unknown>' : node.name.text;
             this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING + className);
         }
         super.visitClassDeclaration(node);

--- a/src/noStatelessClassRule.ts
+++ b/src/noStatelessClassRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-stateless-class',
         type: 'maintainability',
         description: 'A stateless class represents a failure in the object oriented design of the system.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noStringBasedSetImmediateRule.ts
+++ b/src/noStringBasedSetImmediateRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-immediate',
         type: 'maintainability',
         description: 'Do not use the version of setImmediate that accepts code as a string argument.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noStringBasedSetImmediateRule.ts
+++ b/src/noStringBasedSetImmediateRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-immediate',
         type: 'maintainability',
         description: 'Do not use the version of setImmediate that accepts code as a string argument.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noStringBasedSetIntervalRule.ts
+++ b/src/noStringBasedSetIntervalRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-interval',
         type: 'maintainability',
         description: 'Do not use the version of setInterval that accepts code as a string argument.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noStringBasedSetIntervalRule.ts
+++ b/src/noStringBasedSetIntervalRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-interval',
         type: 'maintainability',
         description: 'Do not use the version of setInterval that accepts code as a string argument.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noStringBasedSetTimeoutRule.ts
+++ b/src/noStringBasedSetTimeoutRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-timeout',
         type: 'maintainability',
         description: 'Do not use the version of setTimeout that accepts code as a string argument.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noStringBasedSetTimeoutRule.ts
+++ b/src/noStringBasedSetTimeoutRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         ruleName: 'no-string-based-set-timeout',
         type: 'maintainability',
         description: 'Do not use the version of setTimeout that accepts code as a string argument.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/noSuspiciousCommentRule.ts
+++ b/src/noSuspiciousCommentRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-suspicious-comment',
         type: 'maintainability',
         description: `Do not use suspicious comments, such as ${SUSPICIOUS_WORDS.join(', ')}`,
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noSuspiciousCommentRule.ts
+++ b/src/noSuspiciousCommentRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-suspicious-comment',
         type: 'maintainability',
         description: `Do not use suspicious comments, such as ${SUSPICIOUS_WORDS.join(', ')}`,
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noTypeofUndefinedRule.ts
+++ b/src/noTypeofUndefinedRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Do not use the idiom typeof `x === \'undefined\'`. You can safely use the simpler x === undefined ' +
                     'or perhaps x == null if you want to check for either null or undefined.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noTypeofUndefinedRule.ts
+++ b/src/noTypeofUndefinedRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Do not use the idiom typeof `x === \'undefined\'`. You can safely use the simpler x === undefined ' +
                     'or perhaps x == null if you want to check for either null or undefined.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnexternalizedStringsRule.ts
+++ b/src/noUnexternalizedStringsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unexternalized-strings',
         type: 'maintainability',
         description: 'Ensures that double quoted strings are passed to a localize call to provide proper strings for different locales',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/noUnexternalizedStringsRule.ts
+++ b/src/noUnexternalizedStringsRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unexternalized-strings',
         type: 'maintainability',
         description: 'Ensures that double quoted strings are passed to a localize call to provide proper strings for different locales',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -48,10 +48,14 @@ class NoUnexternalizedStringsRuleWalker extends ErrorTolerantWalker {
 
     constructor(sourceFile: ts.SourceFile, opt: Lint.IOptions) {
         super(sourceFile, opt);
+
+        /* tslint:disable:no-null-keyword */
         this.signatures = Object.create(null);
         this.ignores = Object.create(null);
+        /* tslint:enable:no-null-keyword */
+
         const options: any[] = this.getOptions();
-        const first: UnexternalizedStringsOptions = options && options.length > 0 ? options[0] : null;
+        const first: UnexternalizedStringsOptions = options && options.length > 0 ? options[0] : undefined;
         if (first) {
             if (Array.isArray(first.signatures)) {
                 first.signatures.forEach((signature: string) => this.signatures[signature] = true);
@@ -82,7 +86,7 @@ class NoUnexternalizedStringsRuleWalker extends ErrorTolerantWalker {
         if (info && info.ignoreUsage) {
             return;
         }
-        const callInfo = info ? info.callInfo : null;
+        const callInfo = info ? info.callInfo : undefined;
         if (callInfo && this.ignores[callInfo.callExpression.expression.getText()]) {
             return;
         }
@@ -93,7 +97,7 @@ class NoUnexternalizedStringsRuleWalker extends ErrorTolerantWalker {
         // We have a string that is a direct argument into the localize call.
         const messageArg = callInfo.argIndex === this.messageIndex
             ? callInfo.callExpression.arguments[this.messageIndex]
-            : null;
+            : undefined;
         if (messageArg && messageArg !== node) {
             this.addFailureAt(
                 node.getStart(), node.getWidth(),
@@ -103,9 +107,9 @@ class NoUnexternalizedStringsRuleWalker extends ErrorTolerantWalker {
     }
 
     private findDescribingParent(node: ts.Node):
-        { callInfo?:  { callExpression: ts.CallExpression, argIndex: number }, ignoreUsage?: boolean; } | null {
+        { callInfo?:  { callExpression: ts.CallExpression, argIndex: number }, ignoreUsage?: boolean; } | undefined {
         const kinds = ts.SyntaxKind;
-        while ((node.parent != null)) {
+        while ((node.parent !== undefined)) {
             const parent: ts.Node = node.parent;
             const kind = parent.kind;
             if (kind === kinds.CallExpression) {
@@ -117,10 +121,10 @@ class NoUnexternalizedStringsRuleWalker extends ErrorTolerantWalker {
                 || kind === kinds.MethodDeclaration || kind === kinds.VariableDeclarationList || kind === kinds.InterfaceDeclaration
                 || kind === kinds.ClassDeclaration || kind === kinds.EnumDeclaration || kind === kinds.ModuleDeclaration
                 || kind === kinds.TypeAliasDeclaration || kind === kinds.SourceFile) {
-                    return null;
+                    return undefined;
             }
             node = parent;
         }
-        return null;
+        return undefined;
     }
 }

--- a/src/noUnnecessaryBindRule.ts
+++ b/src/noUnnecessaryBindRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-bind',
         type: 'maintainability',
         description: 'Do not bind `this` as the context for a function literal or lambda expression.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnnecessaryBindRule.ts
+++ b/src/noUnnecessaryBindRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-bind',
         type: 'maintainability',
         description: 'Do not bind `this` as the context for a function literal or lambda expression.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -53,7 +53,7 @@ class NoUnnecessaryBindRuleWalker extends ErrorTolerantWalker {
             if (analyzer.canHandle(node)) {
                 const contextArgument = analyzer.getContextArgument(node);
                 const functionArgument = analyzer.getFunctionArgument(node);
-                if (contextArgument == null || functionArgument == null) {
+                if (contextArgument === undefined || functionArgument === undefined) {
                     return;
                 }
                 if (contextArgument.getText() === 'this') {
@@ -71,8 +71,8 @@ class NoUnnecessaryBindRuleWalker extends ErrorTolerantWalker {
 
 interface CallAnalyzer {
     canHandle(node: ts.CallExpression): boolean;
-    getContextArgument(node: ts.CallExpression): ts.Expression | null;
-    getFunctionArgument(node: ts.CallExpression): ts.Expression | null;
+    getContextArgument(node: ts.CallExpression): ts.Expression | undefined;
+    getFunctionArgument(node: ts.CallExpression): ts.Expression | undefined;
 }
 
 class TypeScriptFunctionAnalyzer implements CallAnalyzer {
@@ -103,7 +103,7 @@ class UnderscoreStaticAnalyzer implements CallAnalyzer {
         return isUnderscore;
     }
 
-    public getContextArgument(node: ts.CallExpression): ts.Expression | null {
+    public getContextArgument(node: ts.CallExpression): ts.Expression | undefined {
         const functionName: string = AstUtils.getFunctionName(node);
         if (Rule.UNDERSCORE_BINARY_FUNCTION_NAMES.indexOf(functionName) !== -1) {
             return node.arguments[2];
@@ -114,10 +114,10 @@ class UnderscoreStaticAnalyzer implements CallAnalyzer {
         } else if (functionName === 'bind') {
             return node.arguments[1];
         }
-        return null;
+        return undefined;
     }
 
-    public getFunctionArgument(node: ts.CallExpression): ts.Expression | null {
+    public getFunctionArgument(node: ts.CallExpression): ts.Expression | undefined {
         const functionName: string = AstUtils.getFunctionName(node);
         if (Rule.UNDERSCORE_BINARY_FUNCTION_NAMES.indexOf(functionName) !== -1) {
             return node.arguments[1];
@@ -128,7 +128,7 @@ class UnderscoreStaticAnalyzer implements CallAnalyzer {
         } else if (functionName === 'bind') {
             return node.arguments[0];
         }
-        return null;
+        return undefined;
     }
 }
 
@@ -144,7 +144,7 @@ class UnderscoreInstanceAnalyzer implements CallAnalyzer {
         return false;
     }
 
-    public getContextArgument(node: ts.CallExpression): ts.Expression | null {
+    public getContextArgument(node: ts.CallExpression): ts.Expression | undefined {
         const functionName: string = AstUtils.getFunctionName(node);
         if (Rule.UNDERSCORE_BINARY_FUNCTION_NAMES.indexOf(functionName) !== -1) {
             return node.arguments[1];
@@ -153,10 +153,10 @@ class UnderscoreInstanceAnalyzer implements CallAnalyzer {
         } else if (functionName === 'sortedIndex') {
             return node.arguments[2];
         }
-        return null;
+        return undefined;
     }
 
-    public getFunctionArgument(node: ts.CallExpression): ts.Expression | null {
+    public getFunctionArgument(node: ts.CallExpression): ts.Expression | undefined {
         const functionName: string = AstUtils.getFunctionName(node);
         if (Rule.UNDERSCORE_BINARY_FUNCTION_NAMES.indexOf(functionName) !== -1) {
             return node.arguments[0];
@@ -165,7 +165,7 @@ class UnderscoreInstanceAnalyzer implements CallAnalyzer {
         } else if (functionName === 'sortedIndex') {
             return node.arguments[1];
         }
-        return null;
+        return undefined;
     }
 
 }

--- a/src/noUnnecessaryFieldInitializationRule.ts
+++ b/src/noUnnecessaryFieldInitializationRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-field-initialization',
         type: 'maintainability',
         description: 'Do not unnecessarily initialize the fields of a class to values they already have.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnnecessaryFieldInitializationRule.ts
+++ b/src/noUnnecessaryFieldInitializationRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-field-initialization',
         type: 'maintainability',
         description: 'Do not unnecessarily initialize the fields of a class to values they already have.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -54,7 +54,7 @@ class UnnecessaryFieldInitializationRuleWalker extends ErrorTolerantWalker {
         const initializer = node.initializer;
         if (node.name.kind === ts.SyntaxKind.Identifier) {
             const fieldName: string = 'this.' + (<ts.Identifier>node.name).getText();
-            if (initializer == null) {
+            if (initializer === undefined) {
                 this.fieldInitializations[fieldName] = undefined;
             } else if (AstUtils.isConstant(initializer)) {
                 this.fieldInitializations[fieldName] = initializer.getText();
@@ -69,7 +69,7 @@ class UnnecessaryFieldInitializationRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitConstructorDeclaration(node: ts.ConstructorDeclaration): void {
-        if (node.body != null) {
+        if (node.body !== undefined) {
             node.body.statements.forEach((statement: ts.Statement): void => {
                 if (statement.kind === ts.SyntaxKind.ExpressionStatement) {
                     const expression: ts.Expression = (<ts.ExpressionStatement>statement).expression;
@@ -85,7 +85,7 @@ class UnnecessaryFieldInitializationRuleWalker extends ErrorTolerantWalker {
                                 if (Object.keys(this.fieldInitializations).indexOf(propertyName) > -1) {
                                     // make sure the field was declared as undefined
                                     const fieldInitValue = this.fieldInitializations[propertyName];
-                                    if (fieldInitValue == null) {
+                                    if (fieldInitValue === undefined) {
                                         const start: number = property.getStart();
                                         const width: number = property.getWidth();
                                         this.addFailureAt(start, width, FAILURE_UNDEFINED_INIT + property.getText());

--- a/src/noUnnecessaryLocalVariableRule.ts
+++ b/src/noUnnecessaryLocalVariableRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-local-variable',
         type: 'maintainability',
         description: 'Do not declare a variable only to return it from the function on the next line.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -56,14 +56,14 @@ class UnnecessaryLocalVariableRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitModuleDeclaration(node: ts.ModuleDeclaration): void {
-        if (node.body != null && tsutils.isModuleBlock(node.body)) {
+        if (node.body !== undefined && tsutils.isModuleBlock(node.body)) {
             this.validateStatementArray(node.body.statements);
         }
         super.visitModuleDeclaration(node);
     }
 
     private validateStatementArray(statements: ts.NodeArray<ts.Statement>): void {
-        if (statements == null || statements.length < 2) {
+        if (statements === undefined || statements.length < 2) {
             return; // one liners are always valid
         }
 
@@ -72,14 +72,14 @@ class UnnecessaryLocalVariableRuleWalker extends ErrorTolerantWalker {
 
         const returnedVariableName = this.tryToGetReturnedVariableName(lastStatement);
         const declaredVariableIdentifier = this.tryToGetDeclaredVariable(nextToLastStatement);
-        if (declaredVariableIdentifier == null) {
+        if (declaredVariableIdentifier === undefined) {
             return;
         }
 
         const declaredVariableName: string = declaredVariableIdentifier.text;
 
-        if (returnedVariableName != null
-            && declaredVariableName != null
+        if (returnedVariableName !== undefined
+            && declaredVariableName !== undefined
             && returnedVariableName === declaredVariableName
             && this.variableIsOnlyUsedOnce(declaredVariableIdentifier)) {
             this.addFailureAt(nextToLastStatement.getStart(), nextToLastStatement.getWidth(),
@@ -87,25 +87,25 @@ class UnnecessaryLocalVariableRuleWalker extends ErrorTolerantWalker {
         }
     }
 
-    private tryToGetDeclaredVariable(statement: ts.Statement): ts.Identifier | null {
-        if (statement != null && tsutils.isVariableStatement(statement)) {
+    private tryToGetDeclaredVariable(statement: ts.Statement): ts.Identifier | undefined {
+        if (statement !== undefined && tsutils.isVariableStatement(statement)) {
             if (statement.declarationList.declarations.length === 1) {
                 const declaration: ts.VariableDeclaration = statement.declarationList.declarations[0];
-                if (declaration.name != null && tsutils.isIdentifier(declaration.name)) {
+                if (declaration.name !== undefined && tsutils.isIdentifier(declaration.name)) {
                     return declaration.name;
                 }
             }
         }
-        return null;
+        return undefined;
     }
 
-    private tryToGetReturnedVariableName(statement: ts.Statement): string | null {
-        if (statement != null && tsutils.isReturnStatement(statement)) {
-            if (statement.expression != null && tsutils.isIdentifier(statement.expression)) {
+    private tryToGetReturnedVariableName(statement: ts.Statement): string | undefined {
+        if (statement !== undefined && tsutils.isReturnStatement(statement)) {
+            if (statement.expression !== undefined && tsutils.isIdentifier(statement.expression)) {
                 return statement.expression.text;
             }
         }
-        return null;
+        return undefined;
     }
 
     private variableIsOnlyUsedOnce(declaredVariableIdentifier: ts.Identifier) {

--- a/src/noUnnecessaryLocalVariableRule.ts
+++ b/src/noUnnecessaryLocalVariableRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-local-variable',
         type: 'maintainability',
         description: 'Do not declare a variable only to return it from the function on the next line.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnnecessaryOverrideRule.ts
+++ b/src/noUnnecessaryOverrideRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-override',
         type: 'maintainability',
         description: 'Do not write a method that only calls super() on the parent method with the same arguments.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnnecessaryOverrideRule.ts
+++ b/src/noUnnecessaryOverrideRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-override',
         type: 'maintainability',
         description: 'Do not write a method that only calls super() on the parent method with the same arguments.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -33,9 +33,9 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoUnnecessaryOverrideRuleWalker extends ErrorTolerantWalker {
     protected visitMethodDeclaration(node: ts.MethodDeclaration): void {
-        if (node.body != null) {
+        if (node.body !== undefined) {
             const statement = this.getSingleStatement(node.body);
-            if (statement != null) {
+            if (statement !== undefined) {
                 if (this.isSuperCall(node, statement) && this.isMatchingArgumentList(node, statement)) {
                     this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING + this.getMethodName(node));
                 }
@@ -44,16 +44,16 @@ class NoUnnecessaryOverrideRuleWalker extends ErrorTolerantWalker {
         super.visitMethodDeclaration(node);
     }
 
-    private getSingleStatement(block: ts.Block): ts.Statement | null {
+    private getSingleStatement(block: ts.Block): ts.Statement | undefined {
         if (block.statements.length === 1) {
             return block.statements[0];
         }
-        return null;
+        return undefined;
     }
 
     private isMatchingArgumentList(node: ts.MethodDeclaration, statement: ts.Statement): boolean {
         const call = this.getCallExpressionFromStatement(statement);
-        if (call == null) {
+        if (call === undefined) {
             return false;
         }
         if (call.arguments.length === 0 && node.parameters.length === 0) {
@@ -87,7 +87,7 @@ class NoUnnecessaryOverrideRuleWalker extends ErrorTolerantWalker {
 
     private isSuperCall(node: ts.MethodDeclaration, statement: ts.Statement): boolean {
         const call = this.getCallExpressionFromStatement(statement);
-        if (call == null) {
+        if (call === undefined) {
             return false;
         }
         if (call.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
@@ -104,26 +104,26 @@ class NoUnnecessaryOverrideRuleWalker extends ErrorTolerantWalker {
         return methodName === declaredMethodName;
     }
 
-    private getCallExpressionFromStatement(statement: ts.Statement): ts.CallExpression | null {
+    private getCallExpressionFromStatement(statement: ts.Statement): ts.CallExpression | undefined {
         let expression: ts.Expression | undefined;
         if (statement.kind === ts.SyntaxKind.ExpressionStatement) {
             expression = (<ts.ExpressionStatement>statement).expression;
         } else if (statement.kind === ts.SyntaxKind.ReturnStatement) {
             expression = (<ts.ReturnStatement>statement).expression;
-            if (expression == null) {
-                return null; // return statements do not have to have an expression
+            if (expression === undefined) {
+                return undefined; // return statements do not have to have an expression
             }
         } else {
-            return null;
+            return undefined;
         }
 
         if (expression.kind !== ts.SyntaxKind.CallExpression) {
-            return null;
+            return undefined;
         }
 
         const call: ts.CallExpression = <ts.CallExpression>expression;
         if (call.expression.kind !== ts.SyntaxKind.PropertyAccessExpression) {
-            return null;
+            return undefined;
         }
         return call;
     }

--- a/src/noUnnecessarySemicolonsRule.ts
+++ b/src/noUnnecessarySemicolonsRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-semicolons',
         type: 'maintainability',
         description: 'Remove unnecessary semicolons',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnnecessarySemicolonsRule.ts
+++ b/src/noUnnecessarySemicolonsRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unnecessary-semicolons',
         type: 'maintainability',
         description: 'Remove unnecessary semicolons',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnsupportedBrowserCodeRule.ts
+++ b/src/noUnsupportedBrowserCodeRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unsupported-browser-code',
         type: 'maintainability',
         description: 'Avoid writing browser-specific code for unsupported browser versions',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUnsupportedBrowserCodeRule.ts
+++ b/src/noUnsupportedBrowserCodeRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-unsupported-browser-code',
         type: 'maintainability',
         description: 'Avoid writing browser-specific code for unsupported browser versions',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noUselessFilesRule.ts
+++ b/src/noUselessFilesRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-useless-files',
         type: 'maintainability',
         description: 'Locates files that only contain commented out code, whitespace characters, or have no content',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: false,
         issueClass: 'Non-SDL',

--- a/src/noUselessFilesRule.ts
+++ b/src/noUselessFilesRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-useless-files',
         type: 'maintainability',
         description: 'Locates files that only contain commented out code, whitespace characters, or have no content',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: false,
         issueClass: 'Non-SDL',

--- a/src/noVarSelfRule.ts
+++ b/src/noVarSelfRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-var-self',
         type: 'maintainability',
         description: 'Do not use var self = this; instead, manage scope with arrow functions/lambdas.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noVarSelfRule.ts
+++ b/src/noVarSelfRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-var-self',
         type: 'maintainability',
         description: 'Do not use var self = this; instead, manage scope with arrow functions/lambdas.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -43,13 +43,13 @@ class NoVarSelfRuleWalker extends Lint.RuleWalker {
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
-        if (options.ruleArguments != null && options.ruleArguments.length > 0) {
+        if (options.ruleArguments !== undefined && options.ruleArguments.length > 0) {
             this.bannedVariableNames = new RegExp(options.ruleArguments[0]);
         }
     }
 
     protected visitVariableDeclaration(node: ts.VariableDeclaration): void {
-        if (node.initializer != null && node.initializer.kind === ts.SyntaxKind.ThisKeyword) {
+        if (node.initializer !== undefined && node.initializer.kind === ts.SyntaxKind.ThisKeyword) {
             if (node.name.kind === ts.SyntaxKind.Identifier) {
                 const identifier: ts.Identifier = <ts.Identifier>node.name;
                 if (this.bannedVariableNames.test(identifier.text)) {

--- a/src/noWithStatementRule.ts
+++ b/src/noWithStatementRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-with-statement',
         type: 'maintainability',
         description: 'Do not use with statements. Assign the item to a new variable instead',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/noWithStatementRule.ts
+++ b/src/noWithStatementRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-with-statement',
         type: 'maintainability',
         description: 'Do not use with statements. Assign the item to a new variable instead',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/nonLiteralFsPathRule.ts
+++ b/src/nonLiteralFsPathRule.ts
@@ -66,7 +66,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'non-literal-fs-path',
         type: 'functionality',
         description: 'Detect calls to fs functions with a non literal filepath',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/nonLiteralFsPathRule.ts
+++ b/src/nonLiteralFsPathRule.ts
@@ -66,7 +66,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'non-literal-fs-path',
         type: 'functionality',
         description: 'Detect calls to fs functions with a non literal filepath',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/nonLiteralRequireRule.ts
+++ b/src/nonLiteralRequireRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'non-literal-require',
         type: 'functionality',
         description: 'Detect require includes that are not for string literals',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/nonLiteralRequireRule.ts
+++ b/src/nonLiteralRequireRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'non-literal-require',
         type: 'functionality',
         description: 'Detect require includes that are not for string literals',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -37,7 +37,7 @@ class NonLiteralRequireRuleWalker extends ErrorTolerantWalker {
 
     protected visitCallExpression(node: ts.CallExpression): void {
         if (AstUtils.getFunctionName(node) === 'require'
-            && AstUtils.getFunctionTarget(node) == null
+            && AstUtils.getFunctionTarget(node) === undefined
             && node.arguments.length > 0) {
 
             if (node.arguments[0].kind === ts.SyntaxKind.ArrayLiteralExpression) {

--- a/src/possibleTimingAttackRule.ts
+++ b/src/possibleTimingAttackRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'possible-timing-attack',
         type: 'functionality',
         description: 'Avoid timing attacks by not making direct comaprisons to sensitive data',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/possibleTimingAttackRule.ts
+++ b/src/possibleTimingAttackRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'possible-timing-attack',
         type: 'functionality',
         description: 'Avoid timing attacks by not making direct comaprisons to sensitive data',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/preferArrayLiteralRule.ts
+++ b/src/preferArrayLiteralRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'prefer-array-literal',
         type: 'maintainability',
         description: 'Use array literal syntax when declaring or instantiating array types.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/preferArrayLiteralRule.ts
+++ b/src/preferArrayLiteralRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'prefer-array-literal',
         type: 'maintainability',
         description: 'Use array literal syntax when declaring or instantiating array types.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/preferTypeCastRule.ts
+++ b/src/preferTypeCastRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'prefer-type-cast',
         type: 'maintainability',
         description: 'Prefer the tradition type casts instead of the new \'as-cast\' syntax',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/preferTypeCastRule.ts
+++ b/src/preferTypeCastRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'prefer-type-cast',
         type: 'maintainability',
         description: 'Prefer the tradition type casts instead of the new \'as-cast\' syntax',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/promiseMustCompleteRule.ts
+++ b/src/promiseMustCompleteRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'When a Promise instance is created, then either the reject() or resolve() parameter must be ' +
                     'called on it within all code branches in the scope.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -37,7 +37,7 @@ class PromiseAnalyzer extends ErrorTolerantWalker {
     private isPromiseDeclaration(node: ts.NewExpression): boolean {
         if (node.expression.kind === ts.SyntaxKind.Identifier
             && node.expression.getText() === 'Promise'
-            && node.arguments != null && node.arguments.length > 0) {
+            && node.arguments !== undefined && node.arguments.length > 0) {
             const firstArg: ts.Expression = node.arguments[0];
             if (firstArg.kind === ts.SyntaxKind.ArrowFunction || firstArg.kind === ts.SyntaxKind.FunctionExpression) {
                 return true;
@@ -48,16 +48,16 @@ class PromiseAnalyzer extends ErrorTolerantWalker {
 
     private getCompletionIdentifiers(declaration: ts.SignatureDeclaration): ts.Identifier[] {
         const result: ts.Identifier[] = [];
-        if (declaration.parameters == null || declaration.parameters.length === 0) {
+        if (declaration.parameters === undefined || declaration.parameters.length === 0) {
             return result;
         }
 
         const arg1: ts.ParameterDeclaration = declaration.parameters[0];
         const arg2: ts.ParameterDeclaration = declaration.parameters[1];
-        if (arg1 != null && arg1.name.kind === ts.SyntaxKind.Identifier) {
+        if (arg1 !== undefined && arg1.name.kind === ts.SyntaxKind.Identifier) {
             result.push(<ts.Identifier>declaration.parameters[0].name);
         }
-        if (arg2 != null && arg2.name.kind === ts.SyntaxKind.Identifier) {
+        if (arg2 !== undefined && arg2.name.kind === ts.SyntaxKind.Identifier) {
             result.push(<ts.Identifier>declaration.parameters[1].name);
         }
         return result;
@@ -126,7 +126,7 @@ class PromiseCompletionWalker extends ErrorTolerantWalker {
 
         if (!ifAnalyzer.isAlwaysCompleted()) {
             this.allBranchesCompleted = false;
-        } else if (node.elseStatement != null) {
+        } else if (node.elseStatement !== undefined) {
             elseAnalyzer.visitNode(node.elseStatement);
             if (!elseAnalyzer.isAlwaysCompleted()) {
                 this.allBranchesCompleted = false;

--- a/src/promiseMustCompleteRule.ts
+++ b/src/promiseMustCompleteRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'When a Promise instance is created, then either the reject() or resolve() parameter must be ' +
                     'called on it within all code branches in the scope.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yAriaUnsupportedElementsRule.ts
+++ b/src/reactA11yAriaUnsupportedElementsRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-aria-unsupported-elements',
         type: 'maintainability',
         description: 'Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yAriaUnsupportedElementsRule.ts
+++ b/src/reactA11yAriaUnsupportedElementsRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-aria-unsupported-elements',
         type: 'maintainability',
         description: 'Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -59,7 +59,7 @@ class ReactA11yAriaUnsupportedElementsWalker extends Lint.RuleWalker {
             return;
         }
 
-        const supportAria: boolean = (<any>DOM_SCHEMA)[tagName].supportAria != null
+        const supportAria: boolean = (<any>DOM_SCHEMA)[tagName].supportAria !== undefined
             ? (<any>DOM_SCHEMA)[tagName].supportAria
             : false;
 

--- a/src/reactA11yEventHasRoleRule.ts
+++ b/src/reactA11yEventHasRoleRule.ts
@@ -21,7 +21,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-event-has-role',
         type: 'maintainability',
         description: 'Elements with event handlers must have role attribute.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yEventHasRoleRule.ts
+++ b/src/reactA11yEventHasRoleRule.ts
@@ -21,7 +21,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-event-has-role',
         type: 'maintainability',
         description: 'Elements with event handlers must have role attribute.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yImageButtonHasAltRule.ts
+++ b/src/reactA11yImageButtonHasAltRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-image-button-has-alt',
         type: 'maintainability',
         description: 'Enforce that inputs element with type="image" must have alt attribute.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yImageButtonHasAltRule.ts
+++ b/src/reactA11yImageButtonHasAltRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-image-button-has-alt',
         type: 'maintainability',
         description: 'Enforce that inputs element with type="image" must have alt attribute.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -91,7 +91,7 @@ class ImgHasAltWalker extends Lint.RuleWalker {
 
         // If element contains JsxSpreadElement in which there could possibly be alt attribute, don't check it.
         const nodeAttributes = getAllAttributesFromJsxElement(node);
-        if (nodeAttributes !== null && nodeAttributes.some(isJsxSpreadAttribute)) {
+        if (nodeAttributes !== undefined && nodeAttributes.some(isJsxSpreadAttribute)) {
             return;
         }
 

--- a/src/reactA11yLangRule.ts
+++ b/src/reactA11yLangRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-lang',
         type: 'functionality',
         description: 'For accessibility of your website, html elements must have a valid lang attribute.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yLangRule.ts
+++ b/src/reactA11yLangRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-lang',
         type: 'functionality',
         description: 'For accessibility of your website, html elements must have a valid lang attribute.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yMetaRule.ts
+++ b/src/reactA11yMetaRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-meta',
         type: 'functionality',
         description: 'For accessibility of your website, HTML meta elements must not have http-equiv="refresh".',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',

--- a/src/reactA11yMetaRule.ts
+++ b/src/reactA11yMetaRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-meta',
         type: 'functionality',
         description: 'For accessibility of your website, HTML meta elements must not have http-equiv="refresh".',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Ignored',
@@ -61,8 +61,8 @@ class ReactA11yMetaRuleWalker extends ErrorTolerantWalker {
         }
     }
 
-    private isStringLiteral(expression: ts.Expression, literal: string): boolean | null {
-        if (expression != null) {
+    private isStringLiteral(expression: ts.Expression, literal: string): boolean | undefined {
+        if (expression !== undefined) {
             if (expression.kind === ts.SyntaxKind.StringLiteral) {
                 const value: string = (<ts.StringLiteral>expression).text;
                 return value === literal;
@@ -74,6 +74,6 @@ class ReactA11yMetaRuleWalker extends ErrorTolerantWalker {
                 }
             }
         }
-        return null;
+        return undefined;
     }
 }

--- a/src/reactA11yPropsRule.ts
+++ b/src/reactA11yPropsRule.ts
@@ -23,7 +23,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-props',
         type: 'maintainability',
         description: 'Enforce all `aria-*` attributes are valid. Elements cannot use an invalid `aria-*` attribute.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yPropsRule.ts
+++ b/src/reactA11yPropsRule.ts
@@ -23,7 +23,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-props',
         type: 'maintainability',
         description: 'Enforce all `aria-*` attributes are valid. Elements cannot use an invalid `aria-*` attribute.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yProptypesRule.ts
+++ b/src/reactA11yProptypesRule.ts
@@ -47,7 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-proptypes',
         type: 'maintainability',
         description: 'Enforce ARIA state and property values are valid.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -78,7 +78,7 @@ class ReactA11yProptypesWalker extends Lint.RuleWalker {
             return;
         }
 
-        const allowUndefined: boolean = aria[propName].allowUndefined != null
+        const allowUndefined: boolean = aria[propName].allowUndefined !== undefined
             ? aria[propName].allowUndefined
             : false;
         const expectedType: string = aria[propName].type;
@@ -106,12 +106,12 @@ class ReactA11yProptypesWalker extends Lint.RuleWalker {
     }
 
     private validityCheck(
-        propValueExpression: ts.Expression | null | undefined,
+        propValueExpression: ts.Expression | undefined,
         propValue: string,
         expectedType: string,
         permittedValues: string[]
     ): boolean {
-        if (propValueExpression == null) {
+        if (propValueExpression === undefined) {
             return true;
         }
 
@@ -132,7 +132,7 @@ class ReactA11yProptypesWalker extends Lint.RuleWalker {
         }
     }
 
-    private isUndefined(node: ts.Expression | null | undefined): boolean {
+    private isUndefined(node: ts.Expression | undefined): boolean {
         if (!node) {
             return true;
         } else if (isJsxExpression(node)) {
@@ -153,8 +153,8 @@ class ReactA11yProptypesWalker extends Lint.RuleWalker {
      * For this case <div prop={ x + 1 } />
      * we can't check the type of atrribute's expression until running time.
      */
-    private isComplexType(node: ts.Expression | null | undefined): boolean {
-        return node != null && !this.isUndefined(node) && isJsxExpression(node) && !AstUtils.isConstant(node.expression);
+    private isComplexType(node: ts.Expression | undefined): boolean {
+        return node !== undefined && !this.isUndefined(node) && isJsxExpression(node) && !AstUtils.isConstant(node.expression);
     }
 
     private isBoolean(node: ts.Expression): boolean {

--- a/src/reactA11yProptypesRule.ts
+++ b/src/reactA11yProptypesRule.ts
@@ -47,7 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-proptypes',
         type: 'maintainability',
         description: 'Enforce ARIA state and property values are valid.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yRoleHasRequiredAriaPropsRule.ts
+++ b/src/reactA11yRoleHasRequiredAriaPropsRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role-has-required-aria-props',
         type: 'maintainability',
         description: 'Elements with aria roles must have all required attributes according to the role.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yRoleHasRequiredAriaPropsRule.ts
+++ b/src/reactA11yRoleHasRequiredAriaPropsRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role-has-required-aria-props',
         type: 'maintainability',
         description: 'Elements with aria roles must have all required attributes according to the role.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yRoleRule.ts
+++ b/src/reactA11yRoleRule.ts
@@ -32,7 +32,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role',
         type: 'maintainability',
         description: 'Elements with aria roles must use a **valid**, **non-abstract** aria role.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yRoleRule.ts
+++ b/src/reactA11yRoleRule.ts
@@ -32,7 +32,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role',
         type: 'maintainability',
         description: 'Elements with aria roles must use a **valid**, **non-abstract** aria role.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yRoleSupportsAriaPropsRule.ts
+++ b/src/reactA11yRoleSupportsAriaPropsRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Enforce that elements with explicit or implicit roles defined contain ' +
         'only `aria-*` properties supported by that `role`.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -78,9 +78,9 @@ class A11yRoleSupportsAriaPropsWalker extends Lint.RuleWalker {
         if (node.tagName.getText().match(/^[A-Z].*/)) {
             return;
         }
-        if (roleProp != null) {
+        if (roleProp !== undefined) {
             roleValue = getStringLiteral(roleProp);
-            if (!isEmpty(roleProp) && roleValue == null) { // Do NOT check if can't retrieve the right role.
+            if (!isEmpty(roleProp) && roleValue === undefined) { // Do NOT check if can't retrieve the right role.
                 return;
             }
         } else {

--- a/src/reactA11yRoleSupportsAriaPropsRule.ts
+++ b/src/reactA11yRoleSupportsAriaPropsRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: 'maintainability',
         description: 'Enforce that elements with explicit or implicit roles defined contain ' +
         'only `aria-*` properties supported by that `role`.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yTabindexNoPositiveRule.ts
+++ b/src/reactA11yTabindexNoPositiveRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-tabindex-no-positive',
         type: 'maintainability',
         description: 'Enforce tabindex value is **not greater than zero**.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yTabindexNoPositiveRule.ts
+++ b/src/reactA11yTabindexNoPositiveRule.ts
@@ -17,7 +17,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-tabindex-no-positive',
         type: 'maintainability',
         description: 'Enforce tabindex value is **not greater than zero**.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-titles',
         type: 'functionality',
         description: 'For accessibility of your website, HTML title elements must be concise and non-empty.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-titles',
         type: 'functionality',
         description: 'For accessibility of your website, HTML title elements must be concise and non-empty.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactAnchorBlankNoopenerRule.ts
+++ b/src/reactAnchorBlankNoopenerRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-anchor-blank-noopener',
         type: 'functionality',
         description: 'Anchor tags with target="_blank" should also include rel="noopener noreferrer"',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -61,7 +61,7 @@ class ReactAnchorBlankNoopenerRuleWalker extends ErrorTolerantWalker {
             const target: ts.JsxAttribute = allAttributes['target'];
             const rel: ts.JsxAttribute = allAttributes['rel'];
             /* tslint:enable:no-string-literal */
-            if (target != null && getStringLiteral(target) === '_blank' && !isRelAttributeValue(rel)) {
+            if (target !== undefined && getStringLiteral(target) === '_blank' && !isRelAttributeValue(rel)) {
                 this.addFailureAt(openingElement.getStart(), openingElement.getWidth(), FAILURE_STRING);
             }
         }
@@ -75,13 +75,13 @@ function isRelAttributeValue(attribute: ts.JsxAttribute): boolean {
 
     if (attribute.initializer !== undefined && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
         const expression: ts.JsxExpression = <ts.JsxExpression>attribute.initializer;
-        if (expression.expression != null && expression.expression.kind !== ts.SyntaxKind.StringLiteral) {
+        if (expression.expression !== undefined && expression.expression.kind !== ts.SyntaxKind.StringLiteral) {
             return true; // attribute value is not a string literal, so do not validate
         }
     }
 
     const stringValue = getStringLiteral(attribute);
-    if (stringValue == null || stringValue.length === 0) {
+    if (stringValue === undefined || stringValue.length === 0) {
         return false;
     }
 

--- a/src/reactAnchorBlankNoopenerRule.ts
+++ b/src/reactAnchorBlankNoopenerRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-anchor-blank-noopener',
         type: 'functionality',
         description: 'Anchor tags with target="_blank" should also include rel="noopener noreferrer"',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/reactIframeMissingSandboxRule.ts
+++ b/src/reactIframeMissingSandboxRule.ts
@@ -34,7 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-iframe-missing-sandbox',
         type: 'functionality',
         description: 'React iframes must specify a sandbox attribute',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -78,7 +78,7 @@ class ReactIframeMissingSandboxRuleWalker extends ErrorTolerantWalker {
                 const attributeName = jsxAttribute.name.text;
                 if (attributeName === 'sandbox') {
                     sandboxAttributeFound = true;
-                    if (jsxAttribute.initializer != null && jsxAttribute.initializer.kind === ts.SyntaxKind.StringLiteral) {
+                    if (jsxAttribute.initializer !== undefined && jsxAttribute.initializer.kind === ts.SyntaxKind.StringLiteral) {
                         this.validateSandboxValue(<ts.StringLiteral>jsxAttribute.initializer);
                     }
                 }

--- a/src/reactIframeMissingSandboxRule.ts
+++ b/src/reactIframeMissingSandboxRule.ts
@@ -34,7 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-iframe-missing-sandbox',
         type: 'functionality',
         description: 'React iframes must specify a sandbox attribute',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/reactNoDangerousHtmlRule.ts
+++ b/src/reactNoDangerousHtmlRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-no-dangerous-html',
         type: 'maintainability',
         description: 'Do not use React\'s dangerouslySetInnerHTML API.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',
@@ -39,7 +39,7 @@ export class Rule extends Lint.Rules.AbstractRule {
      * Exposed for testing.
      */
     /* tslint:disable:function-name */
-    public static getExceptions(options : Lint.IOptions): Exception[] | null {
+    public static getExceptions(options : Lint.IOptions): Exception[] | undefined {
     /* tslint:enable:function-name */
         if (options.ruleArguments instanceof Array) {
             return options.ruleArguments[0];
@@ -47,7 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         if (options instanceof Array) {
             return <Exception[]><any>options; // MSE version of tslint somehow requires this
         }
-        return null;
+        return undefined;
     }
 }
 
@@ -113,14 +113,14 @@ class NoDangerousHtmlWalker extends ErrorTolerantWalker {
 
     private isSuppressed(methodName : string): boolean {
         const exceptions = Rule.getExceptions(this.getOptions());
-        if (exceptions == null || exceptions.length === 0) {
+        if (exceptions === undefined || exceptions.length === 0) {
             return false; // no file specified means the usage is not suppressed
         }
         let found = false;
         exceptions.forEach((exception : Exception) : void => {
             if (Utils.absolutePath(exception.file) === this.getSourceFile().fileName) {
                 if (exception.method === methodName) {
-                    if (exception.comment != null) {
+                    if (exception.comment !== undefined) {
                         found = true;
                     }
                 }

--- a/src/reactNoDangerousHtmlRule.ts
+++ b/src/reactNoDangerousHtmlRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-no-dangerous-html',
         type: 'maintainability',
         description: 'Do not use React\'s dangerouslySetInnerHTML API.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'SDL',

--- a/src/reactThisBindingIssueRule.ts
+++ b/src/reactThisBindingIssueRule.ts
@@ -64,7 +64,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
     private allowedDecorators: Set<string> = new Set<string>();
     private boundListeners: Set<string> = new Set<string>();
     private declaredMethods: Set<string> = new Set<string>();
-    private scope: Scope | null = null;
+    private scope: Scope | undefined;
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
@@ -118,9 +118,9 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
         if (this.isMethodBoundWithDecorators(node, this.allowedDecorators)) {
             this.boundListeners = this.boundListeners.add('this.' + node.name.getText());
         }
-        this.scope = new Scope(null);
+        this.scope = new Scope(undefined);
         super.visitMethodDeclaration(node);
-        this.scope = null;
+        this.scope = undefined;
     }
 
     private isMethodBoundWithDecorators(node: ts.MethodDeclaration, allowedDecorators: Set<string>): boolean {
@@ -138,27 +138,27 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitArrowFunction(node: ts.ArrowFunction): void {
-        if (this.scope != null) {
+        if (this.scope !== undefined) {
             this.scope = new Scope(this.scope);
         }
         super.visitArrowFunction(node);
-        if (this.scope != null) {
+        if (this.scope !== undefined) {
             this.scope = this.scope.parent;
         }
     }
 
     protected visitFunctionExpression(node: ts.FunctionExpression): void {
-        if (this.scope != null) {
+        if (this.scope !== undefined) {
             this.scope = new Scope(this.scope);
         }
         super.visitFunctionExpression(node);
-        if (this.scope != null) {
+        if (this.scope !== undefined) {
             this.scope = this.scope.parent;
         }
     }
 
     protected visitVariableDeclaration(node: ts.VariableDeclaration): void {
-        if (this.scope != null) {
+        if (this.scope !== undefined) {
             if (node.name.kind === ts.SyntaxKind.Identifier) {
                 const variableName = (<ts.Identifier>node.name).text;
                 if (this.isExpressionAnonymousFunction(node.initializer)) {
@@ -212,15 +212,15 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
         }
         if (attributeLikeElement.kind === ts.SyntaxKind.JsxAttribute) {
             const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
-            if (attribute.initializer != null && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
+            if (attribute.initializer !== undefined && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
                 return this.isExpressionAnonymousFunction(attribute.initializer.expression);
             }
         }
         return false;
     }
 
-    private isExpressionAnonymousFunction(expression: ts.Expression | null | undefined): boolean {
-        if (expression == null) {
+    private isExpressionAnonymousFunction(expression: ts.Expression | undefined): boolean {
+        if (expression === undefined) {
             return false;
         }
 
@@ -237,7 +237,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
                 return true; // bind functions on Function or _ create a new anonymous instance of a function
             }
         }
-        if (expression.kind === ts.SyntaxKind.Identifier && this.scope != null) {
+        if (expression.kind === ts.SyntaxKind.Identifier && this.scope !== undefined) {
             const symbolText: string = expression.getText();
             return this.scope.isFunctionSymbol(symbolText);
         }
@@ -247,9 +247,9 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
     private isUnboundListener(attributeLikeElement: ts.JsxAttribute | ts.JsxSpreadAttribute): boolean {
         if (attributeLikeElement.kind === ts.SyntaxKind.JsxAttribute) {
             const attribute: ts.JsxAttribute = <ts.JsxAttribute>attributeLikeElement;
-            if (attribute.initializer != null && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
+            if (attribute.initializer !== undefined && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
                 const jsxExpression = attribute.initializer;
-                if (jsxExpression.expression != null && jsxExpression.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                if (jsxExpression.expression !== undefined && jsxExpression.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
                     const propAccess: ts.PropertyAccessExpression = <ts.PropertyAccessExpression>jsxExpression.expression;
                     if (propAccess.expression.getText() === 'this') {
                         const listenerText: string = propAccess.getText();
@@ -267,7 +267,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
 
     private getSelfBoundListeners(node: ts.ConstructorDeclaration): Set<string> {
         const result: Set<string> = new Set<string>();
-        if (node.body != null && node.body.statements != null) {
+        if (node.body !== undefined && node.body.statements !== undefined) {
             node.body.statements.forEach((statement: ts.Statement): void => {
                 if (statement.kind === ts.SyntaxKind.ExpressionStatement) {
                     const expressionStatement = <ts.ExpressionStatement>statement;
@@ -283,7 +283,7 @@ class ReactThisBindingIssueRuleWalker extends ErrorTolerantWalker {
                                     const callExpression = <ts.CallExpression>binaryExpression.right;
 
                                     if (AstUtils.getFunctionName(callExpression) === 'bind'
-                                        && callExpression.arguments != null
+                                        && callExpression.arguments !== undefined
                                         && callExpression.arguments.length === 1
                                         && callExpression.arguments[0].getText() === 'this') {
 

--- a/src/reactTsxCurlySpacingRule.ts
+++ b/src/reactTsxCurlySpacingRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-tsx-curly-spacing',
         type: 'style',
         description: 'Consistently use spaces around the brace characters of JSX attributes.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactTsxCurlySpacingRule.ts
+++ b/src/reactTsxCurlySpacingRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-tsx-curly-spacing',
         type: 'style',
         description: 'Consistently use spaces around the brace characters of JSX attributes.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -45,7 +45,7 @@ class TsxCurlySpacingWalker extends Lint.RuleWalker {
         this.spacing = options.ruleArguments[0] === 'never' ? Spacing.never : Spacing.always;
         // default value is to not allow multiline
         this.allowMultiline = false;
-        if (options.ruleArguments[1] != null) {
+        if (options.ruleArguments[1] !== undefined) {
             this.allowMultiline = !(options.ruleArguments[1].allowMultiline === false);
         }
     }

--- a/src/reactUnusedPropsAndStateRule.ts
+++ b/src/reactUnusedPropsAndStateRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-unused-props-and-state',
         type: 'maintainability',
         description: 'Remove unneeded properties defined in React Props and State interfaces',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/reactUnusedPropsAndStateRule.ts
+++ b/src/reactUnusedPropsAndStateRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-unused-props-and-state',
         type: 'maintainability',
         description: 'Remove unneeded properties defined in React Props and State interfaces',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -64,7 +64,7 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
 
     private getOptionOrDefault(option: any, key: string, defaultValue: RegExp): RegExp {
         try {
-            if (option[key] != null) {
+            if (option[key] !== undefined) {
                 return new RegExp(option[key]);
             }
         } catch (e) {
@@ -120,12 +120,12 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
         } else if (/this\.state\..*/.test(referencedPropertyName)) {
             this.stateNames = Utils.remove(this.stateNames, referencedPropertyName.substring(11));
         }
-        if (this.propsAlias != null) {
+        if (this.propsAlias !== undefined) {
             if (new RegExp(this.propsAlias + '\\..*').test(referencedPropertyName)) {
                 this.propNames = Utils.remove(this.propNames, referencedPropertyName.substring(this.propsAlias.length + 1));
             }
         }
-        if (this.stateAlias != null) {
+        if (this.stateAlias !== undefined) {
             if (new RegExp(this.stateAlias + '\\..*').test(referencedPropertyName)) {
                 this.stateNames = Utils.remove(this.stateNames, referencedPropertyName.substring(this.stateAlias.length + 1));
             }
@@ -143,7 +143,7 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
     }
 
     protected visitIdentifier(node: ts.Identifier): void {
-        if (this.propsAlias != null) {
+        if (this.propsAlias !== undefined) {
             if (node.text === this.propsAlias
                 && node.parent.kind !== ts.SyntaxKind.PropertyAccessExpression
                 && node.parent.kind !== ts.SyntaxKind.Parameter
@@ -153,7 +153,7 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
             }
 
         }
-        if (this.stateAlias != null) {
+        if (this.stateAlias !== undefined) {
             if (node.text === this.stateAlias
                 && node.parent.kind !== ts.SyntaxKind.PropertyAccessExpression
                 && node.parent.kind !== ts.SyntaxKind.Parameter) {
@@ -194,7 +194,7 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
     private getTypeElementData(node: ts.InterfaceDeclaration): { [index: string]: ts.TypeElement } {
         const result: { [index: string]: ts.TypeElement } = {};
         node.members.forEach((typeElement: ts.TypeElement): void => {
-            if (typeElement.name != null && (<any>typeElement.name).text != null) {
+            if (typeElement.name !== undefined && (<any>typeElement.name).text !== undefined) {
                 result[(<any>typeElement.name).text] = typeElement;
             }
         });
@@ -202,7 +202,7 @@ class ReactUnusedPropsAndStateRuleWalker extends ErrorTolerantWalker {
     }
 
     private isParentNodeSuperCall(node: ts.Node): boolean {
-        if (node.parent != null && node.parent.kind === ts.SyntaxKind.CallExpression) {
+        if (node.parent !== undefined && node.parent.kind === ts.SyntaxKind.CallExpression) {
             const call: ts.CallExpression = <ts.CallExpression>node.parent;
             return call.expression.getText() === 'super';
         }

--- a/src/tests/UtilsTests.ts
+++ b/src/tests/UtilsTests.ts
@@ -7,9 +7,9 @@ import * as chai from 'chai';
 describe('Utils', () : void => {
     describe('contains', (): void => {
         it('should handle empty states', (): void => {
+            // tslint:disable-next-line:no-null-keyword
             chai.expect(Utils.contains([], null)).to.equal(false, 'empty array should not contain false');
             chai.expect(Utils.contains([], undefined)).to.equal(false, 'empty array should not contain undefined');
-            chai.expect(Utils.contains(null, null)).to.equal(false, 'null should not contain false');
             chai.expect(Utils.contains(undefined, undefined)).to.equal(false, 'undefined should not contain undefined');
         });
 
@@ -37,9 +37,7 @@ describe('Utils', () : void => {
 
     describe('removeAll', (): void => {
         it('should handle empty states', (): void => {
-            chai.expect(Utils.removeAll([], null)).to.deep.equal([], 'remove null from empty array');
             chai.expect(Utils.removeAll([], undefined)).to.deep.equal([], 'remove undefined from empty array');
-            chai.expect(Utils.removeAll(null, null)).to.deep.equal([], 'remove null from null');
             chai.expect(Utils.removeAll(undefined, undefined)).to.deep.equal([], 'remove undefined from undefined');
         });
 
@@ -72,7 +70,6 @@ describe('Utils', () : void => {
 
     it('should trim strings properly', (): void => {
         chai.expect(Utils.trimTo(undefined, 10)).to.equal('');
-        chai.expect(Utils.trimTo(null, 10)).to.equal('');
         chai.expect(Utils.trimTo('', 10)).to.equal('');
         chai.expect(Utils.trimTo('123456789', 10)).to.equal('123456789');
         chai.expect(Utils.trimTo('1234567890', 10)).to.equal('1234567890');

--- a/src/underscoreConsistentInvocationRule.ts
+++ b/src/underscoreConsistentInvocationRule.ts
@@ -35,7 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'underscore-consistent-invocation',
         type: 'maintainability',
         description: 'Enforce a consistent usage of the _ functions',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -85,7 +85,7 @@ class UnderscoreConsistentInvocationRuleWalker extends ErrorTolerantWalker {
                 const call: ts.CallExpression = <ts.CallExpression>propExpression.expression;
                 const target = AstUtils.getFunctionTarget(call);
                 const functionName = AstUtils.getFunctionName(call);
-                if (target == null && functionName === '_' && call.arguments.length === 1) {
+                if (target === undefined && functionName === '_' && call.arguments.length === 1) {
                     const underscoreFunctionName = AstUtils.getFunctionName(node);
                     return FUNCTION_NAMES.indexOf(underscoreFunctionName) > -1;
                 }

--- a/src/underscoreConsistentInvocationRule.ts
+++ b/src/underscoreConsistentInvocationRule.ts
@@ -35,7 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'underscore-consistent-invocation',
         type: 'maintainability',
         description: 'Enforce a consistent usage of the _ functions',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/useNamedParameterRule.ts
+++ b/src/useNamedParameterRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'use-named-parameter',
         type: 'maintainability',
         description: 'Do not reference the arguments object by numerical index; instead, use a named parameter.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',
@@ -33,7 +33,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class UseNamedParameterWalker extends ErrorTolerantWalker {
     protected visitElementAccessExpression(node: ts.ElementAccessExpression): void {
-        if (node.argumentExpression != null) {
+        if (node.argumentExpression !== undefined) {
             if (node.argumentExpression.kind === ts.SyntaxKind.NumericLiteral) {
                 if (node.expression.getText() === 'arguments') {
                     const failureString = Rule.FAILURE_STRING + '\'' + node.getText() + '\'';

--- a/src/useNamedParameterRule.ts
+++ b/src/useNamedParameterRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'use-named-parameter',
         type: 'maintainability',
         description: 'Do not reference the arguments object by numerical index; instead, use a named parameter.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/utils/AstUtils.ts
+++ b/src/utils/AstUtils.ts
@@ -23,12 +23,12 @@ export module AstUtils {
         return functionName;
     }
 
-    export function getFunctionTarget(expression: ts.CallExpression): string | null {
+    export function getFunctionTarget(expression: ts.CallExpression): string | undefined {
         if (expression.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
             const propExp: ts.PropertyAccessExpression = <ts.PropertyAccessExpression>expression.expression;
             return propExp.expression.getText();
         }
-        return null;
+        return undefined;
     }
 
     export function isJQuery(functionTarget: string): boolean {
@@ -36,7 +36,7 @@ export module AstUtils {
     }
 
     export function hasModifier(modifiers: ts.ModifiersArray, modifierKind: number): boolean {
-        if (modifiers == null) {
+        if (modifiers === undefined) {
             return false;
         }
         let result: boolean = false;
@@ -91,7 +91,7 @@ export module AstUtils {
             console.log('\ttype.symbol: ' + expressionType.symbol);
 
             const expressionSymbol = typeChecker.getSymbolAtLocation(expression);
-            if (expressionSymbol == null) {
+            if (expressionSymbol === undefined) {
                 console.log('\tsymbol: ' + expressionSymbol);
             } else {
                 console.log('\tsymbol.flags: ' + expressionSymbol.flags);
@@ -100,7 +100,7 @@ export module AstUtils {
             }
 
             const contextualType = typeChecker.getContextualType(expression);
-            if (contextualType == null) {
+            if (contextualType === undefined) {
                 console.log('\tcontextualType: ' + contextualType);
             } else {
                 console.log('\tcontextualType.flags: ' + contextualType.flags);
@@ -112,7 +112,7 @@ export module AstUtils {
 
     export function isPrivate(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        if ((<any>ts).NodeFlags.Private != null) {
+        if ((<any>ts).NodeFlags.Private !== undefined) {
             return !!(node.flags & (<any>ts).NodeFlags.Private);
         } else {
             return !!((<any>ts).getCombinedModifierFlags(node) & (<any>ts).ModifierFlags.Private);
@@ -122,7 +122,7 @@ export module AstUtils {
 
     export function isProtected(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        if ((<any>ts).NodeFlags.Protected != null) {
+        if ((<any>ts).NodeFlags.Protected !== undefined) {
             return !!(node.flags & (<any>ts).NodeFlags.Protected);
         } else {
             return !!((<any>ts).getCombinedModifierFlags(node) & (<any>ts).ModifierFlags.Protected);
@@ -132,7 +132,7 @@ export module AstUtils {
 
     export function isPublic(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        if ((<any>ts).NodeFlags.Public != null) {
+        if ((<any>ts).NodeFlags.Public !== undefined) {
             return !!(node.flags & (<any>ts).NodeFlags.Public);
         } else {
             return !!((<any>ts).getCombinedModifierFlags(node) & (<any>ts).ModifierFlags.Public);
@@ -142,7 +142,7 @@ export module AstUtils {
 
     export function isStatic(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        if ((<any>ts).NodeFlags.Static != null) {
+        if ((<any>ts).NodeFlags.Static !== undefined) {
             return !!(node.flags & (<any>ts).NodeFlags.Static);
         } else {
             return !!((<any>ts).getCombinedModifierFlags(node) & (<any>ts).ModifierFlags.Static);
@@ -159,7 +159,7 @@ export module AstUtils {
     }
 
     function isBindingPattern(node: ts.Node): node is ts.BindingPattern {
-        return node != null && (node.kind === ts.SyntaxKind.ArrayBindingPattern ||
+        return node !== undefined && (node.kind === ts.SyntaxKind.ArrayBindingPattern ||
             node.kind === ts.SyntaxKind.ObjectBindingPattern);
     }
 
@@ -203,7 +203,7 @@ export module AstUtils {
 
     export function isExported(node: ts.Node): boolean {
         /* tslint:disable:no-bitwise */
-        if ((<any>ts).NodeFlags.Export != null) {
+        if ((<any>ts).NodeFlags.Export !== undefined) {
             return !!(getCombinedNodeFlags(node) & (<any>ts).NodeFlags.Export);
         } else {
             // typescript 2.1.4 introduces a new edge case for when
@@ -232,7 +232,7 @@ export module AstUtils {
 
     export function findParentBlock(child: ts.Node): ts.Node {
         let parent: ts.Node = child.parent;
-        while (parent != null) {
+        while (parent !== undefined) {
             if (parent.kind === ts.SyntaxKind.Block) {
                 return parent;
             }
@@ -242,7 +242,7 @@ export module AstUtils {
     }
 
     export function isSameIdentifer(source: ts.Node, target: ts.Node): boolean {
-        if (source == null || target == null) {
+        if (source === undefined || target === undefined) {
             return false;
         }
         if (source.kind === ts.SyntaxKind.Identifier && target.kind === ts.SyntaxKind.Identifier) {
@@ -265,20 +265,20 @@ export module AstUtils {
     }
 
     export function isDeclarationFunctionType(node: ts.PropertyDeclaration | ts.VariableDeclaration | ts.ParameterDeclaration): boolean {
-        if (node.type != null) {
+        if (node.type !== undefined) {
             if (node.type.getText() === 'Function') {
                 return true;
             }
             return node.type.kind === ts.SyntaxKind.FunctionType;
-        } else if (node.initializer != null) {
+        } else if (node.initializer !== undefined) {
             return (node.initializer.kind === ts.SyntaxKind.ArrowFunction
             || node.initializer.kind === ts.SyntaxKind.FunctionExpression);
         }
         return false;
     }
 
-    export function isUndefined(node: ts.Expression | null | undefined): boolean {
-        if (node != null) {
+    export function isUndefined(node: ts.Expression | undefined): boolean {
+        if (node !== undefined) {
             if (node.kind === ts.SyntaxKind.Identifier) {
                 return node.getText() === 'undefined';
             }
@@ -286,8 +286,8 @@ export module AstUtils {
         return false;
     }
 
-    export function isConstant(node: ts.Expression | null | undefined): boolean {
-        if (node == null) {
+    export function isConstant(node: ts.Expression | undefined): boolean {
+        if (node === undefined) {
             return false;
         }
         return node.kind === ts.SyntaxKind.NullKeyword

--- a/src/utils/ChaiUtils.ts
+++ b/src/utils/ChaiUtils.ts
@@ -7,32 +7,32 @@ export module ChaiUtils {
 
     export function isExpectInvocation(node: ts.PropertyAccessExpression | ts.CallExpression): boolean {
         const callExpression = getLeftMostCallExpression(node);
-        if (callExpression == null) {
+        if (callExpression === undefined) {
             return false;
         }
 
         return /.*\.?expect/.test(callExpression.expression.getText());
     }
 
-    export function getExpectInvocation(node: ts.PropertyAccessExpression | ts.CallExpression): ts.CallExpression | null {
+    export function getExpectInvocation(node: ts.PropertyAccessExpression | ts.CallExpression): ts.CallExpression | undefined {
         const callExpression = getLeftMostCallExpression(node, false);
-        if (callExpression == null) {
-            return null;
+        if (callExpression === undefined) {
+            return undefined;
         }
 
         if (/.*\.?expect/.test(callExpression.expression.getText())) {
             return callExpression;
         } else {
-            return null;
+            return undefined;
         }
     }
 
     export function getLeftMostCallExpression(
         node: ts.PropertyAccessExpression | ts.CallExpression,
         checkParent: boolean = false
-    ): ts.CallExpression | null {
+    ): ts.CallExpression | undefined {
         let leftSide: ts.Node = node.expression;
-        while (leftSide != null) {
+        while (leftSide !== undefined) {
             if (leftSide.kind === ts.SyntaxKind.CallExpression) {
                 return <ts.CallExpression>leftSide;
             } else if (leftSide.kind === (ts.SyntaxKind.PropertyAccessExpression)) {
@@ -40,25 +40,25 @@ export module ChaiUtils {
             } else if (checkParent && leftSide.parent.kind === ts.SyntaxKind.CallExpression) {
                 return <ts.CallExpression>leftSide.parent;
             } else {
-                return null; // cannot walk any further left in the property expression
+                return undefined; // cannot walk any further left in the property expression
             }
         }
-        return null;
+        return undefined;
     }
 
-    export function getFirstExpectCallParameter(node: ts.CallExpression): ts.Node | null {
+    export function getFirstExpectCallParameter(node: ts.CallExpression): ts.Node | undefined {
         const expectCall = ChaiUtils.getLeftMostCallExpression(node);
-        if (expectCall != null && expectCall.arguments.length > 0) {
+        if (expectCall !== undefined && expectCall.arguments.length > 0) {
             return expectCall.arguments[0];
         }
-        return null;
+        return undefined;
     }
 
-    export function getFirstExpectationParameter(node: ts.CallExpression): ts.Node | null {
+    export function getFirstExpectationParameter(node: ts.CallExpression): ts.Node | undefined {
         if (node.arguments.length > 0) {
             return node.arguments[0];
         }
-        return null;
+        return undefined;
     }
 
     export function isEqualsInvocation(propExpression: ts.PropertyAccessExpression): boolean {

--- a/src/utils/ErrorTolerantWalker.ts
+++ b/src/utils/ErrorTolerantWalker.ts
@@ -32,7 +32,7 @@ export class ErrorTolerantWalker extends Lint.RuleWalker {
         // Some versions of IE have the word "function" in the constructor name and
         // have the function body there as well. This rips out and returns the function name.
         const result: string = this.constructor.toString().match(/function\s+([\w\$]+)\s*\(/)![1] || '';
-        if (result == null || result.length === 0) {
+        if (result.length === 0) {
             throw new Error('Could not determine class name from input: ' + this.constructor.toString());
         }
         return result;

--- a/src/utils/JsxAttribute.ts
+++ b/src/utils/JsxAttribute.ts
@@ -37,13 +37,13 @@ export function getStringLiteral(node: ts.JsxAttribute | ts.JsxSpreadAttribute):
         throw new Error('The node must be a JsxAttribute collected by the AST parser.');
     }
 
-    const initializer = node == null ? null : node.initializer;
+    const initializer = node === undefined ? undefined : node.initializer;
 
     if (!initializer) { // <tag attribute/>
         return '';
     } else if (isStringLiteral(initializer)) { // <tag attribute='value' />
         return initializer.text.trim();
-    } else if (isJsxExpression(initializer) && initializer.expression != null
+    } else if (isJsxExpression(initializer) && initializer.expression !== undefined
         && isStringLiteral(initializer.expression)) { // <tag attribute={'value'} />
         return (<ts.StringLiteral>initializer.expression).text;
     } else if (isJsxExpression(initializer) && !initializer.expression) { // <tag attribute={} />
@@ -67,8 +67,8 @@ export function getBooleanLiteral(node: ts.JsxAttribute): boolean | undefined {
         throw new Error('The node must be a JsxAttribute collected by the AST parser.');
     }
 
-    const initializer = node == null ? null : node.initializer;
-    if (initializer == null) {
+    const initializer = node === undefined ? undefined : node.initializer;
+    if (initializer === undefined) {
         return false;
     }
 
@@ -87,7 +87,7 @@ export function getBooleanLiteral(node: ts.JsxAttribute): boolean | undefined {
     } else if (isJsxExpression(initializer)) {
         const expression = initializer.expression;
 
-        if (expression == null) {
+        if (expression === undefined) {
             return undefined;
         } else if (isStringLiteral(expression)) {
             return getBooleanFromString(expression.text);
@@ -106,13 +106,13 @@ export function getBooleanLiteral(node: ts.JsxAttribute): boolean | undefined {
 }
 
 export function isEmpty(node: ts.JsxAttribute): boolean {
-    const initializer = node == null ? null : node.initializer;
+    const initializer = node === undefined ? undefined : node.initializer;
 
-    if (initializer == null) {
+    if (initializer === undefined) {
         return true;
     } else if (isStringLiteral(initializer)) {
         return initializer.text.trim() === '';
-    } else if ((<any>initializer).expression != null) {
+    } else if ((<any>initializer).expression !== undefined) {
         const expression: ts.Expression = (<any>initializer).expression;
         if (expression.kind === ts.SyntaxKind.Identifier) {
             return expression.getText() === 'undefined';
@@ -133,21 +133,25 @@ export function getNumericLiteral(node: ts.JsxAttribute): string | undefined {
         throw new Error('The node must be a JsxAttribute collected by the AST parser.');
     }
 
-    const initializer = node == null ? null : node.initializer;
+    const initializer = node === undefined ? undefined : node.initializer;
 
-    return initializer != null && isJsxExpression(initializer) && initializer.expression != null && isNumericLiteral(initializer.expression)
-        ? (<ts.LiteralExpression>initializer.expression).text
-        : undefined;
+    if (initializer !== undefined && isJsxExpression(initializer)) {
+        if (initializer.expression !== undefined && isNumericLiteral(initializer.expression)) {
+            return (<ts.LiteralExpression>initializer.expression).text;
+        }
+    }
+
+    return undefined;
 }
 
 /**
  * Get an array of attributes in the given node.
  * It contains JsxAttribute and JsxSpreadAttribute.
  */
-export function getAllAttributesFromJsxElement(node: ts.Node): ts.NodeArray<ts.JsxAttributeLike> | null {
-    let attributes: ts.NodeArray<ts.JsxAttributeLike> | null = null;
+export function getAllAttributesFromJsxElement(node: ts.Node): ts.NodeArray<ts.JsxAttributeLike> | undefined {
+    let attributes: ts.NodeArray<ts.JsxAttributeLike> | undefined;
 
-    if (node == null) {
+    if (node === undefined) {
         return attributes;
     } else if (isJsxElement(node)) {
         attributes = node.openingElement.attributes.properties;
@@ -170,14 +174,14 @@ export function getJsxAttributesFromJsxElement(node: ts.Node): { [propName: stri
     const attributesDictionary: { [propName: string]: ts.JsxAttribute } = {};
     const attributes = getAllAttributesFromJsxElement(node);
 
-    if (attributes != null) {
+    if (attributes !== undefined) {
         attributes.forEach((attr) => {
             if (!isJsxAttribute(attr)) {
                 return;
             }
 
             const propName = getPropName(attr);
-            if (propName != null) {
+            if (propName !== undefined) {
                 attributesDictionary[propName.toLowerCase()] = attr;
             }
         });

--- a/src/utils/NoStringParameterToFunctionCallWalker.ts
+++ b/src/utils/NoStringParameterToFunctionCallWalker.ts
@@ -30,7 +30,7 @@ export class NoStringParameterToFunctionCallWalker extends ScopedSymbolTrackingW
         const functionTarget = AstUtils.getFunctionTarget(node);
         const functionTargetType = this.getFunctionTargetType(node);
         const firstArg : ts.Expression = node.arguments[0];
-        if (functionName === this.targetFunctionName && firstArg != null) {
+        if (functionName === this.targetFunctionName && firstArg !== undefined) {
             if (functionTarget) {
                 if (functionTargetType) {
                     if (!functionTargetType.match(/^(any|Window|Worker)$/)) {

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -7,10 +7,10 @@ import {AstUtils} from './AstUtils';
  * Tracks nested scope of variables.
  */
 export class Scope {
-    public parent: Scope | null;
+    public parent: Scope | undefined;
     private symbols: { [index: string]: number } = {};
 
-    constructor(parent: Scope | null) {
+    constructor(parent: Scope | undefined) {
         this.parent = parent;
     }
 
@@ -29,7 +29,7 @@ export class Scope {
         if (this.symbols[symbolString] === ts.SyntaxKind.Unknown) {
             return false;
         }
-        if (this.parent != null) {
+        if (this.parent !== undefined) {
             return this.parent.isFunctionSymbol(symbolString);
         }
         return false;

--- a/src/utils/ScopedSymbolTrackingWalker.ts
+++ b/src/utils/ScopedSymbolTrackingWalker.ts
@@ -11,7 +11,7 @@ import {Scope} from './Scope';
  */
 export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
     private typeChecker?: ts.TypeChecker;
-    private scope: Scope | null = null;
+    private scope: Scope | undefined;
 
     constructor(sourceFile : ts.SourceFile, options : Lint.IOptions, program? : ts.Program) {
         super(sourceFile, options);
@@ -21,13 +21,13 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
         }
     }
 
-    protected getFunctionTargetType(expression: ts.CallExpression): string | null {
+    protected getFunctionTargetType(expression: ts.CallExpression): string | undefined {
         if (expression.expression.kind === ts.SyntaxKind.PropertyAccessExpression && this.typeChecker) {
             const propExp : ts.PropertyAccessExpression = <ts.PropertyAccessExpression>expression.expression;
             const targetType: ts.Type = this.typeChecker.getTypeAtLocation(propExp.expression);
             return this.typeChecker.typeToString(targetType);
         }
-        return null;
+        return undefined;
     }
 
     protected isExpressionEvaluatingToFunction(expression : ts.Expression) : boolean {
@@ -45,7 +45,7 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
         }
 
         // is the symbol something we are tracking in scope ourselves?
-        if (this.scope != null && this.scope.isFunctionSymbol(expression.getText())) {
+        if (this.scope !== undefined && this.scope.isFunctionSymbol(expression.getText())) {
             return true;
         }
 
@@ -90,9 +90,9 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
 
     private isFunctionType(expressionType : ts.Type, typeChecker : ts.TypeChecker) : boolean {
         const signatures = typeChecker.getSignaturesOfType(expressionType, ts.SignatureKind.Call);
-        if (signatures != null && signatures.length > 0) {
+        if (signatures !== undefined && signatures.length > 0) {
             const signatureDeclaration = signatures[0].declaration;
-            if (signatureDeclaration != null && signatureDeclaration.kind === ts.SyntaxKind.FunctionType) {
+            if (signatureDeclaration !== undefined && signatureDeclaration.kind === ts.SyntaxKind.FunctionType) {
                 return true; // variables of type function are allowed to be passed as parameters
             }
         }
@@ -100,10 +100,10 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
     }
 
     protected visitSourceFile(node: ts.SourceFile): void {
-        this.scope = new Scope(null);
+        this.scope = new Scope(undefined);
         this.scope.addGlobalScope(node, node, this.getOptions());
         super.visitSourceFile(node);
-        this.scope = null;
+        this.scope = undefined;
     }
 
     protected visitModuleDeclaration(node: ts.ModuleDeclaration): void {
@@ -116,7 +116,7 @@ export class ScopedSymbolTrackingWalker extends ErrorTolerantWalker {
     protected visitClassDeclaration(node: ts.ClassDeclaration): void {
         const scope = this.scope = new Scope(this.scope);
         node.members.forEach((element: ts.ClassElement): void => {
-            const prefix: string = AstUtils.isStatic(element) && node.name != null
+            const prefix: string = AstUtils.isStatic(element) && node.name !== undefined
                 ? node.name.getText() + '.'
                 : 'this.';
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -8,8 +8,8 @@ export module Utils {
     /**
      * Logical 'any' or 'exists' function.
      */
-    export function exists<T>(list : ReadonlyArray<T> | null | undefined, predicate: (t: T) => boolean) : boolean {
-        if (list != null) {
+    export function exists<T>(list : ReadonlyArray<T> | undefined, predicate: (t: T) => boolean) : boolean {
+        if (list !== undefined) {
             for (let i = 0; i < list.length; i++) {
                 const obj : T = list[i];
                 if (predicate(obj)) {
@@ -23,7 +23,7 @@ export module Utils {
     /**
      * A contains function.
      */
-    export function contains<T>(list: ReadonlyArray<T> | null | undefined, element: T): boolean {
+    export function contains<T>(list: ReadonlyArray<T> | undefined, element: T): boolean {
         return exists(list, (item: T): boolean => {
             return item === element;
         });
@@ -33,13 +33,13 @@ export module Utils {
      * A removeAll function.
      */
     export function removeAll<T>(
-        source: ReadonlyArray<T> | null | undefined,
-        elementsToRemove: ReadonlyArray<T> | null | undefined
+        source: ReadonlyArray<T> | undefined,
+        elementsToRemove: ReadonlyArray<T> | undefined
     ): T[] {
-        if (source == null || source.length === 0) {
+        if (source === undefined || source.length === 0) {
             return [];
         }
-        if (elementsToRemove == null || elementsToRemove.length === 0) {
+        if (elementsToRemove === undefined || elementsToRemove.length === 0) {
             return [...source]; // be sure to return a copy of the array
         }
 
@@ -55,8 +55,8 @@ export module Utils {
         return removeAll(source, [elementToRemove]);
     }
 
-    export function trimTo(source: string | null | undefined, maxLength: number): string {
-        if (source == null) {
+    export function trimTo(source: string | undefined, maxLength: number): string {
+        if (source === undefined) {
             return '';
         }
         if (source.length <= maxLength) {

--- a/src/utils/getImplicitRole.ts
+++ b/src/utils/getImplicitRole.ts
@@ -10,10 +10,10 @@ import { isJsxElement, isJsxSelfClosingElement, isJsxOpeningElement } from './Ty
  * A reference about implicit role: https://www.w3.org/TR/html-aria/#sec-strong-native-semantics.
  * A reference about no corresponding role: https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role.
  */
-export function getImplicitRole(node: ts.Node | null | undefined): string | undefined {
+export function getImplicitRole(node: ts.Node | undefined): string | undefined {
     let tagName: string | undefined;
 
-    if (node == null) {
+    if (node === undefined) {
         return undefined;
     } else if (isJsxElement(node)) {
         tagName = node.openingElement.tagName.getText();

--- a/src/validTypeofRule.ts
+++ b/src/validTypeofRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'valid-typeof',
         type: 'maintainability',
         description: 'Ensures that the results of typeof are compared against a valid string.',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/src/validTypeofRule.ts
+++ b/src/validTypeofRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'valid-typeof',
         type: 'maintainability',
         description: 'Ensures that the results of typeof are compared against a valid string.',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,
         issueClass: 'Non-SDL',

--- a/templates/rule.snippet
+++ b/templates/rule.snippet
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: '%RULE_NAME%',
         type: 'maintainability',    // one of: 'functionality' | 'maintainability' | 'style' | 'typescript'
         description: '... add a meaningful one line description',
-        options: undefined,
+        options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         optionExamples: [],         //Remove this property if the rule has no options
         typescriptOnly: false,

--- a/templates/rule.snippet
+++ b/templates/rule.snippet
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: '%RULE_NAME%',
         type: 'maintainability',    // one of: 'functionality' | 'maintainability' | 'style' | 'typescript'
         description: '... add a meaningful one line description',
-        options: null,
+        options: undefined,
         optionsDescription: '',
         optionExamples: [],         //Remove this property if the rule has no options
         typescriptOnly: false,

--- a/tslint.json
+++ b/tslint.json
@@ -145,7 +145,7 @@
     "no-multiline-string": [ false ],
     "no-multiple-var-decl": false,
     "no-namespace": false,
-    "no-null-keyword": false,
+    "no-null-keyword": true,
     "no-octal-literal": true,
     "no-parameter-properties": false,
     "no-reference": true,


### PR DESCRIPTION
Fixes #490.

I've changed the code to use `undefined` instead of `null`, except where it's actually needed, which was only a handful of places:

* Creating an object without a prototype [here](https://github.com/Microsoft/tslint-microsoft-contrib/blob/dea2835101911f669dde46387833a8e57e054e89/src/noUnexternalizedStringsRule.ts#L51-L52)
* Checking the results of regular expression tests [here](https://github.com/Microsoft/tslint-microsoft-contrib/blob/dea2835101911f669dde46387833a8e57e054e89/src/maxFuncBodyLengthRule.ts#L133), [here](https://github.com/Microsoft/tslint-microsoft-contrib/blob/dea2835101911f669dde46387833a8e57e054e89/src/noJqueryRawElementsRule.ts#L73) and [here](https://github.com/Microsoft/tslint-microsoft-contrib/blob/dea2835101911f669dde46387833a8e57e054e89/src/noRegexSpacesRule.ts#L37)

There's one thing I'm not sure if I should change (I've left it unchanged for now). The [additional_rule_metadata.json](https://github.com/Microsoft/tslint-microsoft-contrib/blob/dea2835101911f669dde46387833a8e57e054e89/additional_rule_metadata.json#L347-L355) and [recommended_ruleset.js](https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/recommended_ruleset.js#L141) files both suggest turning the `no-null-keyword` off. Given that it's now turned _on_, do those files need to change?