### PR TITLE
[import-name] Fix #378

### DIFF
--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -151,6 +151,9 @@ class ImportNameRuleWalker extends Lint.RuleWalker {
 
     private validateImport(node: ts.ImportEqualsDeclaration | ts.ImportDeclaration, importedName: string, moduleName: string): void {
         let expectedImportedName = moduleName.replace(/.*\//, ''); // chop off the path
+        if (expectedImportedName === '' || expectedImportedName === '.' || expectedImportedName === '..') {
+            return;
+        }
         expectedImportedName = this.makeCamelCase(expectedImportedName);
         if (this.isImportNameValid(importedName, expectedImportedName, moduleName, node) === false) {
             const message: string = `Misnamed import. Import should be named '${expectedImportedName}' but found '${importedName}'`;

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -220,4 +220,26 @@ describe('importNameRule', () : void => {
             }
         ]);
     });
+
+    it('should pass on index path modules', () => {
+        const script = `
+            import AnyName = require('.');
+            import AnyName = require('..');
+            import AnyName = require('./');
+            import AnyName = require('../');
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
+
+    it('should pass on index path ES6 modules', () => {
+        const script = `
+            import AnyName from '.';
+            import AnyName from '..';
+            import AnyName from './';
+            import AnyName from '../';
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [ ]);
+    });
 });


### PR DESCRIPTION
Fixes #378
- ignore modules that have dotted paths like `.`, `..`, `./`