### PR TITLE
Fix Alt-text cannot be an image file name #217

### DIFF
--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -35,6 +35,10 @@ export function getFailureStringEmptyAltAndNotEmptyTitle(tagName: string): strin
 its title attribute is not empty. Remove the title attribute.`;
 }
 
+export function getFailureStringAltIsImageFileName(tagName: string): string {
+    return `The value of alt attribute in <${tagName}> tag is an image file name. Give meaningful value to the alt attribute `;
+}
+
 /**
  * Enforces that img elements have alt text.
  */
@@ -43,7 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-img-has-alt',
         type: 'maintainability',
         description: 'Enforce that an img element contains the non-empty alt attribute. ' +
-        'For decorative images, using empty alt attribute and role="presentation".',
+            'For decorative images, using empty alt attribute and role="presentation".',
         options: 'string[]',
         optionsDescription: '',
         optionExamples: ['true', '[true, ["Image"]]'],
@@ -114,7 +118,8 @@ class ImgHasAltWalker extends Lint.RuleWalker {
             const allowNonEmptyAltWithRolePresentation: boolean = options.length > 1
                 ? options[1].allowNonEmptyAltWithRolePresentation
                 : false;
-
+            const imageFileNameRegex: RegExp = new RegExp('^.*\\.(jpg|bmp|jpeg|jfif|gif|png|tif|tiff)$', 'i');
+            const isAltImageFileName: boolean = !isEmptyAlt && imageFileNameRegex.test(getStringLiteral(altAttribute) || '');
             // <img alt='altValue' role='presentation' />
             if (!isEmptyAlt && isPresentationRole && !allowNonEmptyAltWithRolePresentation && !titleAttribute) {
                 this.addFailureAt(
@@ -133,6 +138,12 @@ class ImgHasAltWalker extends Lint.RuleWalker {
                     node.getStart(),
                     node.getWidth(),
                     getFailureStringEmptyAltAndNotEmptyTitle(tagName)
+                );
+            } else if (isAltImageFileName) {
+                this.addFailureAt(
+                    node.getStart(),
+                    node.getWidth(),
+                    getFailureStringAltIsImageFileName(tagName)
                 );
             }
         }

--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -13,6 +13,7 @@ import { isJsxSpreadAttribute } from './utils/TypeGuard';
 const ROLE_STRING: string = 'role';
 const ALT_STRING: string = 'alt';
 const TITLE_STRING: string = 'title';
+const IMAGE_FILENAME_REGEX: RegExp = new RegExp('^.*\\.(jpg|bmp|jpeg|jfif|gif|png|tif|tiff)$', 'i');
 
 export function getFailureStringNoAlt(tagName: string): string {
     return `<${tagName}> elements must have an non-empty alt attribute or \
@@ -118,8 +119,7 @@ class ImgHasAltWalker extends Lint.RuleWalker {
             const allowNonEmptyAltWithRolePresentation: boolean = options.length > 1
                 ? options[1].allowNonEmptyAltWithRolePresentation
                 : false;
-            const imageFileNameRegex: RegExp = new RegExp('^.*\\.(jpg|bmp|jpeg|jfif|gif|png|tif|tiff)$', 'i');
-            const isAltImageFileName: boolean = !isEmptyAlt && imageFileNameRegex.test(getStringLiteral(altAttribute) || '');
+            const isAltImageFileName: boolean = !isEmptyAlt && IMAGE_FILENAME_REGEX.test(getStringLiteral(altAttribute) || '');
             // <img alt='altValue' role='presentation' />
             if (!isEmptyAlt && isPresentationRole && !allowNonEmptyAltWithRolePresentation && !titleAttribute) {
                 this.addFailureAt(

--- a/src/tests/reactA11yImgHasAltRuleTests.ts
+++ b/src/tests/reactA11yImgHasAltRuleTests.ts
@@ -4,7 +4,8 @@ import {
   getFailureStringEmptyAltAndNotEmptyTitle,
   getFailureStringEmptyAltAndNotPresentationRole,
   getFailureStringNoAlt,
-  getFailureStringNonEmptyAltAndPresentationRole
+  getFailureStringNonEmptyAltAndPresentationRole,
+  getFailureStringAltIsImageFileName
 } from '../reactA11yImgHasAltRule';
 
 /**
@@ -202,6 +203,38 @@ const c = <img alt={''} title='Some image' role='presentation' />;
               ruleName: ruleName,
               startPosition: { character: 11, line: 5 },
               failure: getFailureStringEmptyAltAndNotEmptyTitle('img')
+            }
+          ]
+        );
+      });
+      it('when the img element has non-empty alt value but it\'s an image filename', () => {
+        const fileName: string = `import React = require('react');
+        const a = <img alt='altvalue.gif' />;
+        const b = <img alt='altvalue.jpeg' />;
+        const c = <img alt={'altvalue.png'} />;
+        `;
+
+        TestHelper.assertViolations(
+          ruleName,
+          fileName,
+          [
+            {
+              name: Utils.absolutePath('file.tsx'),
+              ruleName: ruleName,
+              startPosition: { character: 19, line: 2 },
+              failure: getFailureStringAltIsImageFileName('img')
+            },
+            {
+              name: Utils.absolutePath('file.tsx'),
+              ruleName: ruleName,
+              startPosition: { character: 19, line: 3 },
+              failure: getFailureStringAltIsImageFileName('img')
+            },
+            {
+              name: Utils.absolutePath('file.tsx'),
+              ruleName: ruleName,
+              startPosition: { character: 19, line: 4 },
+              failure: getFailureStringAltIsImageFileName('img')
             }
           ]
         );


### PR DESCRIPTION
Fixes #217, by adding a regex to check for most common file formats in use. 
Can use some feedback on the error text and any additional formats that might have been missed