### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,8 @@ To develop tslint-microsoft-contrib simply clone the repository, install depende
     grunt all
     grunt create-rule --rule-name=no-something-or-other
 
+Please also see our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ### Debug code
 
 If command fails because of file access permissions, prefix it with sudo.
@@ -1223,6 +1225,3 @@ Set a breakpoint somewhere in your code and resume execution. Your breakpoint sh
 ### Creating a new Release
 
 Refer to the [Releases Wiki Page](https://github.com/Microsoft/tslint-microsoft-contrib/wiki/Releases)
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Just so that people can find the code of conduct file easily. Also, this is the standard way how most open source repositories do it.