### PR TITLE
Removed `npm start` "dependency" on `npm test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,8 +1243,6 @@ Two npm scripts can be used to watch files and simplify testing and linting with
 
 Use `npm start` to start watcher that will rebuild rules and Mocha tests.
 
-> NOTE: Run `npm test` before `npm start` to copy all required files to `dist` folder.
-
 Use `npm run watch:run-tests` that will re-run tests (both Mocha and TSLint) and lint code when: files changed in `tests`, `test-data` or `npm start` compiled rules or tests code.
 
 > NOTE: It is recommended to wait when `npm start` will finish initial compilation before starting `npm run watch:run-tests` (in separate terminal).

--- a/package.json
+++ b/package.json
@@ -49,14 +49,15 @@
     "generate:package-json-for-npm": "node build-tasks/generate-package-json-for-npm.js",
     "lint:rules": "tslint -p tsconfig.json -t stylish -c tslint.json -e \"src/tests/**\" \"src/**/*.ts\"",
     "lint:tests": "tslint -p tsconfig.json -t stylish -c src/tests/tslint.json -e src/tests/references.ts \"src/tests/**/*.ts\"",
-    "start": "tsc --watch",
+    "start": "npm-run-all clean copy:json watch:src",
     "test:mocha": "mocha \"dist/src/tests/**/*.js\" --timeout 5000",
     "test:rules": "tslint -r dist/src --test \"tests/**\"",
     "test": "npm-run-all clean copy:json tsc:src test:* lint:* validate:* copy:package copy:meta generate:*",
     "tsc:src": "tsc",
     "validate:config": "node build-tasks/validate-config.js",
     "validate:documentation": "node build-tasks/validate-documentation.js",
-    "watch:run-tests": "node build-tasks/watch-run-tests.js"
+    "watch:run-tests": "node build-tasks/watch-run-tests.js",
+    "watch:src": "tsc --watch"
   },
   "dependencies": {
     "tsutils": "^2.27.2 <2.29.0"


### PR DESCRIPTION
As described in #618 - there is easy improvement for `start` script.

As I can see on my PC this will add 3.5-5.5s before watcher startup, but now `npm test` isn't required before starting watcher.

Removes line that was moved to separate file in #617.