### PR TITLE
Add regex option to no-suspicious-comment rule

### DIFF
--- a/src/noSuspiciousCommentRule.ts
+++ b/src/noSuspiciousCommentRule.ts
@@ -39,7 +39,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoSuspiciousCommentRuleWalker extends Lint.RuleWalker {
 
-    private exceptionRegex: RegExp[] = [];
+    private readonly exceptionRegex: RegExp[] = [];
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);

--- a/src/noSuspiciousCommentRule.ts
+++ b/src/noSuspiciousCommentRule.ts
@@ -1,8 +1,8 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
-import {forEachTokenWithTrivia} from 'tsutils';
-import {ExtendedMetadata} from './utils/ExtendedMetadata';
+import { forEachTokenWithTrivia } from 'tsutils';
+import { ExtendedMetadata } from './utils/ExtendedMetadata';
 
 const FAILURE_STRING: string = 'Suspicious comment found: ';
 const SUSPICIOUS_WORDS = ['BUG', 'HACK', 'FIXME', 'LATER', 'LATER2', 'TODO'];
@@ -13,8 +13,15 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'no-suspicious-comment',
         type: 'maintainability',
         description: `Do not use suspicious comments, such as ${SUSPICIOUS_WORDS.join(', ')}`,
-        options: null, // tslint:disable-line:no-null-keyword
-        optionsDescription: '',
+        options: {
+            type: 'array',
+            items: {
+                type: 'string'
+            }
+        },
+        optionsDescription: `One argument may be optionally provided: \n\n' +
+            '* an array of regex that disable the warning if one or several of them
+            are found in the comment text. (Example: \`['https://github.com/my-org/my-project/']\`)`,
         typescriptOnly: true,
         issueClass: 'Non-SDL',
         issueType: 'Warning',
@@ -31,6 +38,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoSuspiciousCommentRuleWalker extends Lint.RuleWalker {
 
+    private exceptionRegex: RegExp[] = [];
+
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+        super(sourceFile, options);
+        if (options.ruleArguments !== undefined && options.ruleArguments.length > 0) {
+            options.ruleArguments.forEach((regexStr: string) => {
+                this.exceptionRegex.push(new RegExp(regexStr));
+            });
+        }
+    }
+
     public visitSourceFile(node: ts.SourceFile) {
         forEachTokenWithTrivia(node, (text, tokenSyntaxKind, range) => {
             if (tokenSyntaxKind === ts.SyntaxKind.SingleLineCommentTrivia ||
@@ -41,6 +59,9 @@ class NoSuspiciousCommentRuleWalker extends Lint.RuleWalker {
     }
 
     private scanCommentForSuspiciousWords(startPosition: number, commentText: string): void {
+        if (this.commentContainsExceptionRegex(this.exceptionRegex, commentText)) {
+            return;
+        }
         SUSPICIOUS_WORDS.forEach((suspiciousWord: string) => {
             this.scanCommentForSuspiciousWord(suspiciousWord, commentText, startPosition);
         });
@@ -57,5 +78,14 @@ class NoSuspiciousCommentRuleWalker extends Lint.RuleWalker {
     private foundSuspiciousComment(startPosition: number, commentText: string, suspiciousWord: string) {
         const errorMessage: string = FAILURE_STRING + suspiciousWord;
         this.addFailureAt(startPosition, commentText.length, errorMessage);
+    }
+
+    private commentContainsExceptionRegex(exceptionRegex: RegExp[], commentText: string): boolean {
+        for (const regex of exceptionRegex) {
+            if (regex.test(commentText)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/tests/NoSuspiciousCommentRuleTests.ts
+++ b/src/tests/NoSuspiciousCommentRuleTests.ts
@@ -7,7 +7,7 @@ import {TestHelper} from './TestHelper';
 describe('noSuspiciousCommentRule', (): void => {
 
     const ruleName: string = 'no-suspicious-comment';
-    const option: string[]  = ['https\:\/\/example.com\/*'];
+    const option: string[]  = ['https://example.com/*'];
 
     it('should pass on normal comments', (): void => {
         const script: string = `
@@ -85,6 +85,13 @@ describe('noSuspiciousCommentRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [{
                 "failure": `Suspicious comment found: ${suspiciousWord}`,
+                "name": Utils.absolutePath("file.ts"),
+                "ruleName": "no-suspicious-comment",
+                "startPosition": {"character": 17, "line": 2}
+            }]);
+            TestHelper.assertViolationsWithOptions(ruleName, option, script, [{
+                "failure": `Suspicious comment found: ${suspiciousWord}.
+To disable this warning, the comment should include one of the following regex: /https:\\/\\/example.com\\/*/`,
                 "name": Utils.absolutePath("file.ts"),
                 "ruleName": "no-suspicious-comment",
                 "startPosition": {"character": 17, "line": 2}

--- a/src/tests/NoSuspiciousCommentRuleTests.ts
+++ b/src/tests/NoSuspiciousCommentRuleTests.ts
@@ -7,6 +7,7 @@ import {TestHelper} from './TestHelper';
 describe('noSuspiciousCommentRule', (): void => {
 
     const ruleName: string = 'no-suspicious-comment';
+    const option: string[]  = ['https\:\/\/example.com\/*'];
 
     it('should pass on normal comments', (): void => {
         const script: string = `
@@ -14,6 +15,7 @@ describe('noSuspiciousCommentRule', (): void => {
         `;
 
         TestHelper.assertViolations(ruleName, script, []);
+        TestHelper.assertViolationsWithOptions(ruleName, option, script, []);
     });
 
     it('should pass on multi-line comments', (): void => {
@@ -53,6 +55,17 @@ describe('noSuspiciousCommentRule', (): void => {
         }]);
     });
 
+    it('should pass on multiline TODO comments with regex option', (): void => {
+        const script: string = `
+            /**
+            * TODO: add failing example and update assertions
+            * See https://example.com/article/123
+            */
+        `;
+
+        TestHelper.assertViolationsWithOptions(ruleName, option, script, []);
+    });
+
     it('should pass on lower case todo comments without colons', (): void => {
         const script: string = `
             // todo add failing example and update assertions
@@ -78,6 +91,14 @@ describe('noSuspiciousCommentRule', (): void => {
             }]);
         });
 
+        it(`should pass on upper case ${suspiciousWord} comments without colons and with regex option`, (): void => {
+            const script: string = `
+                // ${suspiciousWord} you should fix this https://example.com/article/123
+            `;
+
+            TestHelper.assertViolationsWithOptions(ruleName, option, script, []);
+        });
+
         it(`should fail on upper case ${suspiciousWord} comments with colons`, (): void => {
             const script: string = `
                 // ${suspiciousWord}: you should fix this
@@ -91,6 +112,14 @@ describe('noSuspiciousCommentRule', (): void => {
             }]);
         });
 
+        it(`should pass on upper case ${suspiciousWord} comments with colons and with regex option`, (): void => {
+            const script: string = `
+                // ${suspiciousWord}: you should fix this (see https://example.com/article/123)
+            `;
+
+            TestHelper.assertViolationsWithOptions(ruleName, option, script, []);
+        });
+
         it(`should fail on lower case ${suspiciousWord} comments with colons`, (): void => {
             const script: string = `
                 // ${suspiciousWord}: you should fix this
@@ -102,6 +131,14 @@ describe('noSuspiciousCommentRule', (): void => {
                 "ruleName": "no-suspicious-comment",
                 "startPosition": {"character": 17, "line": 2}
             }]);
+        });
+
+        it(`should pass on lower case ${suspiciousWord} comments with colons and with regex option`, (): void => {
+            const script: string = `
+                // ${suspiciousWord}: you should fix this  (see https://example.com/article/123)
+            `;
+
+            TestHelper.assertViolationsWithOptions(ruleName, option, script, []);
         });
     });
 });


### PR DESCRIPTION
Fix #440.

* Add option to ignore warning if the comment matches a given regex
* Mention the regex in the rule warning message if activated