### PR TITLE
Stubbed out appveyor.xml's contents

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,2 @@
-# Test against a newer version and an older version of Node.js
-environment:
-  matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
-
-install:
-  # Get the latest stable version of Node.js
-  - ps: Install-Product node $env:nodejs_version
-  - npm install
-
-test_script:
-  # Output useful info for debugging.
-  - node --version
-  - npm --version
-  # run tests
-  - npm test
-
 # Don't actually build.
 build: off


### PR DESCRIPTION
Pending disabling Appveyor to allow #621, starts on #613 by doing nothing in the Appveyor build.

This is nice because Appveyor tends to be slower than Travis and we don't want to be bogged down by it.