### PR TITLE
Removed mentions of now-deprecated formatters from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,15 +1197,6 @@ There certainly are a lot of options! Here are some links to get you started.
   </tbody>
 </table>
 
-### Supported Formatters
-
-These formatters assume that you use the UTF-8 file encoding. They may not work if you have a different encoding, especially if your encoding uses a 2-byte line ending (such as `\r\n` on Windows).
-
-| Formatter Name           | Description                                                                                                                                                                                                                                                                                                                                                                                 | Since |
-| :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
-| `fix-no-require-imports` | This formatter automatically converts imports from the require syntax to the ES6 syntax. For example `import Utils = require('Utils');` becomes `import {Utils} from 'Utils';`. However, be warned that the fix assumes that your imported module exports the correct thing. If anything goes wrong with your exports then you'll get a compiler failure saying there is no default export. | 2.0.8 |
-| `fix-no-var-keyword`     | This formatter automatically converts var variable declarations into let variable declarations found by the no-var-keyword rule.                                                                                                                                                                                                                                                            | 2.0.8 |
-
 ## Development
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/build-tasks/common/meta.js
+++ b/build-tasks/common/meta.js
@@ -80,23 +80,7 @@ function getContribRuleNames() {
         .sort();
 }
 
-function getAllFormatterNames() {
-    const convertToFormatterNames = filename => {
-        filename = filename
-            .replace(/Formatter\..*/, '') // file extension plus Formatter suffix
-            .replace(/.*\//, ''); // leading path
-
-        return kebabCase(filename);
-    };
-
-    const formatters = glob.sync('src/*Formatter.ts').map(convertToFormatterNames);
-    formatters.sort();
-
-    return formatters;
-}
-
 module.exports = {
-    getAllFormatterNames,
     getContribRuleNames,
     getAllRules,
     getMetadataFromFile,

--- a/build-tasks/validate-documentation.js
+++ b/build-tasks/validate-documentation.js
@@ -4,23 +4,15 @@
  */
 
 const { yellowBright } = require('chalk');
-const { readFile, readJSON } = require('./common/files');
-const { getAllFormatterNames, getContribRuleNames } = require('./common/meta');
+const { readFile } = require('./common/files');
+const { getContribRuleNames } = require('./common/meta');
 
 const readmeText = readFile('README.md');
-const packageJson = readJSON('package.json');
 const validationErrors = [];
 
 getContribRuleNames().forEach(ruleName => {
     if (readmeText.indexOf(ruleName) === -1) {
         validationErrors.push('A rule was found that is not documented in README.md: ' + ruleName);
-    }
-});
-
-getAllFormatterNames().forEach(formatterName => {
-    if (readmeText.indexOf(formatterName) === -1) {
-        validationErrors.push('A formatter was found that is not documented in README.md: ' + formatterName);
-        validationFailed = true;
     }
 });
 


### PR DESCRIPTION
Continues #577.