### PR TITLE
Added issue and PR templates as near-copies of TSLint core's

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+### Bug Report
+
+-   **`tslint-microsoft-contrib` version**:
+-   **TSLint version**:
+-   **TypeScript version**:
+-   **Running TSLint via**: (pick one) CLI / Node.js API / VSCode / grunt-tslint / Atom / Visual Studio / etc
+
+#### TypeScript code being linted
+
+```tsx
+// code snippet
+```
+
+with `tslint.json` configuration:
+
+```json
+
+```
+
+#### Actual behavior
+
+#### Expected behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a bug in `tslint-microsoft-contrib`
+---
+
+### Bug Report
+
+-   **`tslint-microsoft-contrib` version**:
+-   **TSLint version**:
+-   **TypeScript version**:
+-   **Running TSLint via**: (pick one) CLI / Node.js API / VSCode / grunt-tslint / Atom / Visual Studio / etc
+
+#### TypeScript code being linted
+
+```tsx
+// code snippet
+```
+
+with `tslint.json` configuration:
+
+```json
+
+```
+
+#### Actual behavior
+
+#### Expected behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest a non-rule idea for `tslint-microsoft-contrib``
+---
+
+### Feature request
+
+**Is your feature request that we implement a new rule?**
+Please use the `Rule Suggestion` template instead
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/rule-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/rule-suggestion.md
@@ -1,0 +1,14 @@
+---
+name: Rule suggestion
+about: Suggest a new rule for `tslint-microsoft-contrib``
+---
+
+### Rule Suggestion
+
+**Is your rule for a general problem or is it specific to your development style?**
+
+**What does your suggested rule do?**
+
+**List several examples where your rule could be used**
+
+**Additional context**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+#### PR checklist
+
+-   [ ] Addresses an existing issue: fixes #0000
+-   [ ] New feature, bugfix, or enhancement
+    -   [ ] Includes tests
+-   [ ] Documentation update
+
+#### Overview of change:
+
+#### Is there anything you'd like reviewers to focus on?
+
+<!-- optional -->


### PR DESCRIPTION
Adds a request for `tslint-microsoft-contrib`'s version and removes mention of a changelog entry. Otherwise approximately identical to what TSLint itself uses.

Fixes #582. Fixes #583.