### PR TITLE
Remove absolute path from rules error messages.

### DIFF
--- a/src/exportNameRule.ts
+++ b/src/exportNameRule.ts
@@ -158,21 +158,13 @@ export class ExportNameWalker extends Lint.RuleWalker {
     private validateExport(exportedName: string, node: ts.Node): void {
         const flags = Rule.getIgnoreCase(this.getOptions()) ? 'i' : '';
         const regex: RegExp = new RegExp(exportedName + '..*', flags); // filename must be exported name plus any extension
-        if (!regex.test(this.getFilename())) {
+        const fileName = Utils.fileBasename(this.getSourceFile().fileName);
+        if (!regex.test(fileName)) {
             if (!this.isSuppressed(exportedName)) {
-                const failureString: string = Rule.FAILURE_STRING + this.getSourceFile().fileName + ' and ' + exportedName;
+                const failureString: string = Rule.FAILURE_STRING + fileName + ' and ' + exportedName;
                 this.addFailureAt(node.getStart(), node.getWidth(), failureString);
             }
         }
-    }
-
-    private getFilename(): string {
-        const filename = this.getSourceFile().fileName;
-        const lastSlash = filename.lastIndexOf('/');
-        if (lastSlash > -1) {
-            return filename.substring(lastSlash + 1);
-        }
-        return filename;
     }
 
     private isSuppressed(exportedName: string): boolean {

--- a/src/missingJsdocRule.ts
+++ b/src/missingJsdocRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         recommendation: 'false,'
     };
 
-    public static FAILURE_STRING: string = 'File missing JSDoc comment at the top-level: ';
+    public static FAILURE_STRING: string = 'File missing JSDoc comment at the top-level.';
 
     private static isWarningShown: boolean = false;
 
@@ -35,8 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class MissingJSDocWalker extends Lint.RuleWalker {
     protected visitSourceFile(node: ts.SourceFile): void {
         if (!/^\/\*\*\s*$/gm.test(node.getFullText())) {
-            const failureString = Rule.FAILURE_STRING + this.getSourceFile().fileName;
-            this.addFailureAt(node.getStart(), node.getWidth(), failureString);
+            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
         }
         // do not continue walking
     }

--- a/src/reactNoDangerousHtmlRule.ts
+++ b/src/reactNoDangerousHtmlRule.ts
@@ -101,10 +101,7 @@ class NoDangerousHtmlWalker extends Lint.RuleWalker {
             const failureString =
                 'Invalid call to dangerouslySetInnerHTML in method "' +
                 this.currentMethodName +
-                '"\n' +
-                '    of source file ' +
-                this.getSourceFile().fileName +
-                '"\n' +
+                '".\n' +
                 '    Do *NOT* add a suppression for this warning. If you absolutely must use this API then you need\n' +
                 '    to review the usage with a security expert/QE representative. If they decide that this is an\n' +
                 '    acceptable usage then add the exception to xss_exceptions.json';

--- a/src/tests/ExportNameRuleTests.ts
+++ b/src/tests/ExportNameRuleTests.ts
@@ -243,7 +243,7 @@ describe('exportNameRule', (): void => {
                 {
                     failure:
                         'The exported module or identifier name must match the file name. ' +
-                        'Found: test-data/ExportName/ExportNameRuleFailingTestInput.ts and ThisIsNotTheNameOfTheFile',
+                        'Found: ExportNameRuleFailingTestInput.ts and ThisIsNotTheNameOfTheFile',
                     name: 'test-data/ExportName/ExportNameRuleFailingTestInput.ts',
                     ruleName: 'export-name',
                     startPosition: { character: 10, line: 2 }
@@ -257,7 +257,7 @@ describe('exportNameRule', (): void => {
                 {
                     failure:
                         'The exported module or identifier name must match the file name. ' +
-                        'Found: test-data/ExportName/ExportNameRuleFailingTestInput2.tsx and ThisIsNotTheNameOfTheFile',
+                        'Found: ExportNameRuleFailingTestInput2.tsx and ThisIsNotTheNameOfTheFile',
                     name: 'test-data/ExportName/ExportNameRuleFailingTestInput2.tsx',
                     ruleName: 'export-name',
                     startPosition: { character: 10, line: 2 }
@@ -274,10 +274,7 @@ describe('exportNameRule', (): void => {
             `;
             TestHelper.assertViolations(ruleName, inputScript, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and NotMatching',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and NotMatching',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 21, line: 3 }
@@ -293,10 +290,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example1',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example1',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: {
@@ -315,10 +309,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example2',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example2',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 17, line: 2 }
@@ -334,10 +325,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example3',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example3',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 17, line: 2 }
@@ -354,10 +342,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example3a',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example3a',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 17, line: 3 }
@@ -373,10 +358,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example4',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example4',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 28, line: 2 }
@@ -392,10 +374,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example5',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example5',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 30, line: 2 }
@@ -411,10 +390,7 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, [
                 {
-                    failure:
-                        'The exported module or identifier name must match the file name. Found: ' +
-                        Utils.absolutePath('file.ts') +
-                        ' and Example6',
+                    failure: 'The exported module or identifier name must match the file name. Found: file.ts and Example6',
                     name: Utils.absolutePath('file.ts'),
                     ruleName: 'export-name',
                     startPosition: { character: 28, line: 2 }

--- a/src/tests/MissingJsdocRuleTests.ts
+++ b/src/tests/MissingJsdocRuleTests.ts
@@ -30,7 +30,7 @@ function whatever() { }`;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                failure: 'File missing JSDoc comment at the top-level: ' + Utils.absolutePath('file.ts'),
+                failure: 'File missing JSDoc comment at the top-level.',
                 name: Utils.absolutePath('file.ts'),
                 ruleName: 'missing-jsdoc',
                 startPosition: { character: 1, line: 2 }
@@ -47,7 +47,7 @@ function whatever() { }`;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                failure: 'File missing JSDoc comment at the top-level: ' + Utils.absolutePath('file.ts'),
+                failure: 'File missing JSDoc comment at the top-level.',
                 name: Utils.absolutePath('file.ts'),
                 ruleName: 'missing-jsdoc',
                 startPosition: { character: 1, line: 5 }
@@ -64,7 +64,7 @@ function whatever() { }`;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                failure: 'File missing JSDoc comment at the top-level: ' + Utils.absolutePath('file.ts'),
+                failure: 'File missing JSDoc comment at the top-level.',
                 name: Utils.absolutePath('file.ts'),
                 ruleName: 'missing-jsdoc',
                 startPosition: { character: 1, line: 5 }
@@ -81,7 +81,7 @@ function whatever() { }`;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                failure: 'File missing JSDoc comment at the top-level: ' + Utils.absolutePath('file.ts'),
+                failure: 'File missing JSDoc comment at the top-level.',
                 name: Utils.absolutePath('file.ts'),
                 ruleName: 'missing-jsdoc',
                 startPosition: { character: 1, line: 5 }
@@ -98,7 +98,7 @@ function whatever() { }`;
 
         TestHelper.assertViolations(ruleName, script, [
             {
-                failure: 'File missing JSDoc comment at the top-level: ' + Utils.absolutePath('file.ts'),
+                failure: 'File missing JSDoc comment at the top-level.',
                 name: Utils.absolutePath('file.ts'),
                 ruleName: 'missing-jsdoc',
                 startPosition: { character: 5, line: 5 }

--- a/src/tests/ReactNoDangerousHtmlRuleTests.ts
+++ b/src/tests/ReactNoDangerousHtmlRuleTests.ts
@@ -22,9 +22,8 @@ function someFunction() {
             [
                 {
                     failure:
-                        'Invalid call to dangerouslySetInnerHTML in method "<unknown>"\n    of source file ' +
-                        Utils.absolutePath('file.tsx') +
-                        '"\n    Do *NOT* add a suppression for this warning. ' +
+                        'Invalid call to dangerouslySetInnerHTML in method "<unknown>".' +
+                        '\n    Do *NOT* add a suppression for this warning. ' +
                         'If you absolutely must use this API then you need\n    to review the usage with a security expert/QE ' +
                         'representative. If they decide that this is an\n    acceptable usage then add the exception ' +
                         'to xss_exceptions.json',
@@ -34,9 +33,8 @@ function someFunction() {
                 },
                 {
                     failure:
-                        'Invalid call to dangerouslySetInnerHTML in method "<unknown>"\n    of source file ' +
-                        Utils.absolutePath('file.tsx') +
-                        '"\n    Do *NOT* add a suppression for this warning. ' +
+                        'Invalid call to dangerouslySetInnerHTML in method "<unknown>".' +
+                        '\n    Do *NOT* add a suppression for this warning. ' +
                         'If you absolutely must use this API then you need\n    to review the usage with a security expert/QE ' +
                         'representative. If they decide that this is an\n    acceptable usage then add the exception ' +
                         'to xss_exceptions.json',

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -71,5 +71,9 @@ export namespace Utils {
         // Replaces \ with / to match format of ts.SourceFile.fileName on Windows
         return path.resolve(relativePath).replace(/\\/g, '/');
     }
+
+    export function fileBasename(relativePath: string): string {
+        return path.basename(relativePath);
+    }
 }
 /* tslint:enable:no-increment-decrement */


### PR DESCRIPTION
#### PR checklist

-   [X] Addresses an existing issue: fixes #634 
-   [X] ~New feature,~ bugfix, ~or enhancement~
    -   [X] Includes tests
-   [ ] Documentation update

#### Overview of change:

- `export-name` now has only base file name in error message.
- `missing-jsdoc` removed filename from error message
- `react-no-dangerous-html` filename from error message

I haven't changed how string concatenations is made for multiline errors because anyway they will be migrated soon.

#### Is there anything you'd like reviewers to focus on?

Added inline comment.


This PR with template looks better and important :)