### PR TITLE
Upgrade prettier version to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,9 +3298,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.0.tgz",
+      "integrity": "sha512-NtSOnDRmJaNuruoX0KhDdQ3UGyLNJaSuP2eJn6Q6uSvzQBAJQHZbXgraFPbv8sYbNaMR9nz7scMy55WC+78E6w==",
       "dev": true
     },
     "pretty-format": {
@@ -3371,7 +3371,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lint-staged": "^8.0.4",
     "mocha": "5.2.0",
     "npm-run-all": "^4.1.3",
-    "prettier": "1.14.3",
+    "prettier": "1.15.0",
     "rimraf": "^2.6.2",
     "strip-json-comments": "^2.0.1",
     "tslint": "^5.11.0",

--- a/src/tests/FunctionNameRuleTests.ts
+++ b/src/tests/FunctionNameRuleTests.ts
@@ -321,17 +321,19 @@ describe('functionNameRule', (): void => {
     describe('reading options', (): void => {
         let options: [boolean, object];
 
-        beforeEach((): void => {
-            options = [
-                true,
-                {
-                    'method-regex': '^myMethod$',
-                    'private-method-regex': '^myPrivateMethod$',
-                    'static-method-regex': '^myStaticMethod$',
-                    'function-regex': '^myFunction$'
-                }
-            ];
-        });
+        beforeEach(
+            (): void => {
+                options = [
+                    true,
+                    {
+                        'method-regex': '^myMethod$',
+                        'private-method-regex': '^myPrivateMethod$',
+                        'static-method-regex': '^myStaticMethod$',
+                        'function-regex': '^myFunction$'
+                    }
+                ];
+            }
+        );
 
         it('should allow passing names', (): void => {
             const script: string = `

--- a/src/tests/NoInnerHtmlRuleTests.ts
+++ b/src/tests/NoInnerHtmlRuleTests.ts
@@ -90,14 +90,16 @@ describe('noInnerHtmlRule', (): void => {
     describe('with options', (): void => {
         let options: [boolean, object];
 
-        beforeEach((): void => {
-            options = [
-                true,
-                {
-                    'html-lib-matcher': 'cheerio|[j|J][q|Q]uery'
-                }
-            ];
-        });
+        beforeEach(
+            (): void => {
+                options = [
+                    true,
+                    {
+                        'html-lib-matcher': 'cheerio|[j|J][q|Q]uery'
+                    }
+                ];
+            }
+        );
 
         it('should fail on invoking html(x) with different jQuery matcher', (): void => {
             const script: string = `


### PR DESCRIPTION
#### PR checklist

- [x] Enhancement

#### Overview of change:

https://prettier.io/blog/2018/11/07/1.15.0.html

Prettier just came out with a new version. Because we upgraded to prettier a few days back, I think we are in the position to upgrade to the latest prettier version as of now.