### PR TITLE
node.getWidth() in no-backbone-get-set-outside-model

### DIFF
--- a/src/noBackboneGetSetOutsideModelRule.ts
+++ b/src/noBackboneGetSetOutsideModelRule.ts
@@ -34,11 +34,11 @@ class NoBackboneGetSetOutsideModelRuleWalker extends Lint.RuleWalker {
             const functionName: string = AstUtils.getFunctionName(node);
             if (functionName === 'get' && node.arguments.length === 1 && node.arguments[0].kind === ts.SyntaxKind.StringLiteral) {
                 const msg: string = Rule.GET_FAILURE_STRING + node.getText();
-                this.addFailureAt(node.getStart(), node.getEnd(), msg);
+                this.addFailureAt(node.getStart(), node.getWidth(), msg);
             }
             if (functionName === 'set' && node.arguments.length === 2 && node.arguments[0].kind === ts.SyntaxKind.StringLiteral) {
                 const msg: string = Rule.SET_FAILURE_STRING + node.getText();
-                this.addFailureAt(node.getStart(), node.getEnd(), msg);
+                this.addFailureAt(node.getStart(), node.getWidth(), msg);
             }
         }
         super.visitCallExpression(node);


### PR DESCRIPTION
😄

#### PR checklist

-   [x] Addresses an existing issue: fixes #662 
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests

#### Overview of change:

Used proper end lengths of lint warnings in `no-backbone-get-set-outside-model`.
