### PR TITLE
Avoid exception on re-exports (fixes #664)

### DIFF
--- a/src/exportNameRule.ts
+++ b/src/exportNameRule.ts
@@ -86,12 +86,16 @@ function isExportStatement(node: ts.Statement): node is ExportStatement {
 function getExportsFromStatement(node: ExportStatement): [string, ts.Node][] {
     if (ts.isExportAssignment(node)) {
         return [[node.expression.getText(), node.expression]];
-    } else {
+    } else if (node.exportClause) {
         const symbolAndNodes: [string, ts.Node][] = [];
-        node.exportClause!.elements.forEach(e => {
+        node.exportClause.elements.forEach(e => {
             symbolAndNodes.push([e.name.getText(), node]);
         });
         return symbolAndNodes;
+    } else {
+        // Re-exports `export * from ...` do not have export clause - no names to validate.
+        // Effectively will be skipped in check later.
+        return [];
     }
 }
 

--- a/tests/export-name/defaults/re-export-external.ts.lint
+++ b/tests/export-name/defaults/re-export-external.ts.lint
@@ -1,0 +1,2 @@
+// should be skipped - no names to validate
+export * from './other';

--- a/tests/export-name/defaults/tslint.json
+++ b/tests/export-name/defaults/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "export-name": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

-   [X] Addresses an existing issue: fixes #664
-   [X] New feature, **bugfix**, or enhancement
    -   [X] Includes tests

#### Overview of change:
Full module re-exports do not have `exportClause` with list of re-exported names. After this change existence of `exportClause` is verified and 

#### Is there anything you'd like reviewers to focus on?
Migration of test for `export-name` rule almost finished in local branch so I've used TSLint test format for this change instead of Mocha tests modification. Has same folder structure and config, but includes only specific test file.

At this point I do not see an easy way to perform same verifications for module which is re-exported in current file. Therefore decided to just ignore full module re-exports (`export * from …`).

Probably this will be possible with (optionally) typed rule, however I'm not sure if TS will provide list of exported names. Should I create new issue to track this improvement?
