### PR TITLE
react-a11y-no-onchange rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,16 +941,6 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
     </tr>
     <tr>
       <td>
-        <code>use-simple-attributes</code>
-      </td>
-      <td>
-        Simpler attributes in JSX and TSX files helps keep code clean and readable.
-        Separate complex expressions into their own line and use clear variable names to make your code more understandable.
-      </td>
-      <td>6.0.0</td>
-    </tr>
-    <tr>
-      <td>
         <code>react-a11y-props</code>
       </td>
       <td>
@@ -1200,6 +1190,16 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
         This rule is similar to JSLint's <a href="https://jslinterrors.com/use-a-named-parameter">Use a named parameter</a> rule.
       </td>
       <td>0.0.3</td>
+    </tr>
+    <tr>
+      <td>
+        <code>use-simple-attributes</code>
+      </td>
+      <td>
+        Simpler attributes in JSX and TSX files helps keep code clean and readable.
+        Separate complex expressions into their own line and use clear variable names to make your code more understandable.
+      </td>
+      <td>6.0.0</td>
     </tr>
     <tr>
       <td>

--- a/README.md
+++ b/README.md
@@ -931,6 +931,11 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
       </td>
       <td>
         For accessibility of your website, enforce usage of onBlur over onChange on select menus.
+        References:
+        <ul>
+          <li><a href="http://cita.disability.uiuc.edu/html-best-practices/auto/onchange.php">OnChange Event Accessibility Issues</a></li>
+          <li><a href="https://www.w3.org/TR/WCAG10/wai-pageauth.html#gl-own-interface">Guideline 8. Ensure direct accessibility of embedded user interfaces.</a></li>
+        </ul>
       </td>
       <td>6.0.0-beta</td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
         <ul>
           <li><a href="https://www.w3.org/TR/WCAG10/wai-pageauth.html#tech-text-equivalent">Web Content Accessibility Guidelines 1.0</a></li>
           <li><a href="https://www.w3.org/TR/wai-aria/roles#presentation">ARIA Presentation Role</a></li>
-          <li><a href="http://oaa-accessibility.org/wcag20/rule/31">WCAG Rule 31: If an image has an alt or title attribute, it should not have a presentation role</a>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/31">WCAG Rule 31: If an image has an alt or title attribute, it should not have a presentation role</a></li>
         </ul>
       </td>
       <td>2.0.11</td>

--- a/src/reactA11yAnchorsRule.ts
+++ b/src/reactA11yAnchorsRule.ts
@@ -29,6 +29,13 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-anchors',
         type: 'functionality',
         description: 'For accessibility of your website, anchor elements must have a href different from # and a text longer than 4.',
+        rationale: `References:
+        <ul>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/38">WCAG Rule 38: Link text should be as least four 4 characters long</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/39">WCAG Rule 39: Links with the same HREF should have the same link text</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/41">WCAG Rule 41: Links that point to different HREFs should have different link text</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/43">WCAG Rule 43: Links with images and text content, the alt attribute should be unique to the text content or empty</a></li>
+        </ul>`,
         options: {
             type: 'array',
             items: {

--- a/src/reactA11yEventHasRoleRule.ts
+++ b/src/reactA11yEventHasRoleRule.ts
@@ -38,6 +38,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-event-has-role',
         type: 'maintainability',
         description: 'Elements with event handlers must have role attribute.',
+        rationale: `References:
+        <ul>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/94">WCAG Rule 94</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role">
+            Using the button role
+          </a></li>
+        </ul>
+        `,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yImgHasAltRule.ts
+++ b/src/reactA11yImgHasAltRule.ts
@@ -46,6 +46,12 @@ export class Rule extends Lint.Rules.AbstractRule {
             'Enforce that an img element contains the non-empty alt attribute. ' +
             'For decorative images, using empty alt attribute and role="presentation".',
         options: 'string[]',
+        rationale: `References:
+        <ul>
+          <li><a href="https://www.w3.org/TR/WCAG10/wai-pageauth.html#tech-text-equivalent">Web Content Accessibility Guidelines 1.0</a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria/roles#presentation">ARIA Presentation Role</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/31">WCAG Rule 31: If an image has an alt or title attribute, it should not have a presentation role</a></li>
+        </ul>`,
         optionsDescription: '',
         optionExamples: ['true', '[true, ["Image"]]'],
         typescriptOnly: true,

--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -16,6 +16,15 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-input-elements',
         type: 'functionality',
         description: 'For accessibility of your website, HTML input boxes and text areas must include default, place-holding characters.',
+        rationale: `References:
+        <ul>
+          <li><a href="https://www.w3.org/TR/WAI-WEBCONTENT-TECHS/#tech-place-holders">
+            WCAG 10.4
+          </a></li>
+          <li><a href="https://www.w3.org/TR/WCAG10-HTML-TECHS/#forms-specific">
+            WCAG 11.5
+          </a></li>
+        </ul>`,
         options: undefined,
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yLangRule.ts
+++ b/src/reactA11yLangRule.ts
@@ -164,6 +164,18 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-lang',
         type: 'functionality',
         description: 'For accessibility of your website, html elements must have a valid lang attribute.',
+        rationale: `References:
+        <ul>
+          <li><a href="https://www.w3.org/TR/WCAG20-TECHS/H58.html">
+            H58: Using language attributes to identify changes in the human language
+          </a></li>
+          <li><a href="https://dequeuniversity.com/rules/axe/1.1/valid-lang">
+            lang attribute must have a valid value
+          </a></li>
+          <li><a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">
+            List of ISO 639-1 codes
+          </a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yNoOnchangeRule.ts
+++ b/src/reactA11yNoOnchangeRule.ts
@@ -12,6 +12,12 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-no-onchange',
         type: 'functionality',
         description: 'For accessibility of your website, enforce usage of onBlur over onChange on select menus.',
+        rationale: `References:
+        <ul>
+          <li><a href="http://cita.disability.uiuc.edu/html-best-practices/auto/onchange.php">OnChange Event Accessibility Issues</a></li>
+          <li><a href="https://www.w3.org/TR/WCAG10/wai-pageauth.html#gl-own-interface">Guideline 8. Ensure direct accessibility of embedded user interfaces.</a></li>
+        </ul>
+        `,
         options: 'string[]',
         optionsDescription: 'Additional tag names to validate.',
         optionExamples: ['true', '[true, ["Select"]]'],

--- a/src/reactA11yRequiredRule.ts
+++ b/src/reactA11yRequiredRule.ts
@@ -13,6 +13,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-required',
         type: 'functionality',
         description: 'Enforce that required input elements must have aria-required set to true',
+        rationale: `References:
+        <ul>
+          <li><a href="http://www.clarissapeterson.com/2012/11/html5-accessibility/">Acessibility in HTML5</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yRoleHasRequiredAriaPropsRule.ts
+++ b/src/reactA11yRoleHasRequiredAriaPropsRule.ts
@@ -39,6 +39,12 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role-has-required-aria-props',
         type: 'maintainability',
         description: 'Elements with aria roles must have all required attributes according to the role.',
+        rationale: `References:
+        <ul>
+          <li><a href="https://www.w3.org/TR/wai-aria/roles#role_definitions">ARIA Definition of Roles</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/90">WCAG Rule 90: Required properties and states should be defined</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/91">WCAG Rule 91: Required properties and states must not be empty</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yRoleRule.ts
+++ b/src/reactA11yRoleRule.ts
@@ -33,7 +33,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: ExtendedMetadata = {
         ruleName: 'react-a11y-role',
         type: 'maintainability',
-        description: 'Elements with aria roles must use a **valid**, **non-abstract** aria role.',
+        description: `Elements with aria roles must use a **valid**, **non-abstract** aria role.
+        A reference to role definitions can be found at [WAI-ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions).`,
+        rationale: `References:
+        <ul>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/92">WCAG Rule 92: Role value must be valid</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yRoleSupportsAriaPropsRule.ts
+++ b/src/reactA11yRoleSupportsAriaPropsRule.ts
@@ -40,7 +40,16 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-role-supports-aria-props',
         type: 'maintainability',
         description:
-            'Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.',
+        'Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.' +
+        'Many aria attributes (states and properties) can only be used on elements with particular roles.' +
+        "Some elements have implicit roles, such as `<a href='hrefValue' />`, which will be resolved to `role='link'`." +
+        'A reference for the implicit roles can be found at [Default Implicit ARIA Semantics](https://www.w3.org/TR/html-aria/#sec-strong-native-semantics).',
+        rationale: `References:
+        <ul>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/87">ARIA attributes can only be used with certain roles</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/84">Check aria properties and states for valid roles and properties</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/93">Check that 'ARIA-' attributes are valid properties and states</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yTabindexNoPositiveRule.ts
+++ b/src/reactA11yTabindexNoPositiveRule.ts
@@ -17,6 +17,12 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-tabindex-no-positive',
         type: 'maintainability',
         description: 'Enforce tabindex value is **not greater than zero**.',
+        rationale: `References:
+        <ul>
+          <li><a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-focus-order">WCAG 2.4.3 - Focus Order</a></li>
+          <li><a href="https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#tabindex-usage">Audit Rules - tabindex-usage</a></li>
+          <li><a href="https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_03">Avoid positive integer values for tabIndex</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,

--- a/src/reactA11yTitlesRule.ts
+++ b/src/reactA11yTitlesRule.ts
@@ -14,6 +14,13 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: 'react-a11y-titles',
         type: 'functionality',
         description: 'For accessibility of your website, HTML title elements must be concise and non-empty.',
+        rationale: `References:
+        <ul>
+          <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">WCAG 2.0 - Requirement 2.4.2 Page Titled (Level A)</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/13">OAA-Accessibility Rule 13: Title element should not be empty</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/24">OAA-Accessibility Rule 24: Title content should be concise</a></li>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/25">OAA-Accessibility Rule 25: Title text must contain more than one word</a></li>
+        </ul>`,
         options: null, // tslint:disable-line:no-null-keyword
         optionsDescription: '',
         typescriptOnly: true,


### PR DESCRIPTION
#### PR checklist

-   [ ] Addresses an existing issue: fixes #0000
-   [ ] New feature, bugfix, or enhancement
    -   [ ] Includes tests
-   [x] Documentation update

#### Overview of change:

As part of updating https://github.com/bettermarks/bm-tslint-rules to v6 of this rule set I was checking the rules that have been added.
Because there was no reference mentioned for `react-a11y-no-onchange` I did some searching and found a page that seemed to be a good fit as a reference.

I checked and found that most other `react-a11y-*` rules have this information as part of the "supported rules" table in the README.
Because I'm the developer of https://github.com/karfau/tslint-report (that adds rules metadata to it's reports) and I like generated documentation since it reduces the burden of keeping things in sync manually, I also added the references for all `react-a11y-*` rules to the `rationale`field of their metadata.

When I found `metadata.description` didn't match the README and it was easy to do I updated the metadata accordingly. Since some of them contained markdown instead of HTML I sticked to that in the decsription field.

Along the way I also found some minor issues in the README that I fixed:
- an unclosed `li` tag
- a rule that was not at the correct place regarding to alphabetical order

#### Is there anything you'd like reviewers to focus on?
* I used template strings for the rationale, to be able to just copy paste the multi-line strings. I hope it is supported in all target environments or will be transpiled accordingly?
* Currently the `rationale` contains HTML but the descriptions have markdown. I would be willing to also convert the `rationale` values to markdown if requested.