### PR TITLE
convert chai-vague-errors rule to use walk function

### DIFF
--- a/src/chaiVagueErrorsRule.ts
+++ b/src/chaiVagueErrorsRule.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
 
 import { ChaiUtils } from './utils/ChaiUtils';
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
@@ -28,52 +29,55 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new ChaiVagueErrorsRuleWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class ChaiVagueErrorsRuleWalker extends Lint.RuleWalker {
-    protected visitPropertyAccessExpression(node: ts.PropertyAccessExpression): void {
-        if (ChaiUtils.isExpectInvocation(node)) {
-            if (/ok|true|false|undefined|null/.test(node.name.getText())) {
-                const expectInvocation = ChaiUtils.getExpectInvocation(node);
-                if (!expectInvocation || expectInvocation.arguments.length !== 2) {
-                    this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    function cb(node: ts.Node): void {
+        if (tsutils.isPropertyAccessExpression(node)) {
+            if (ChaiUtils.isExpectInvocation(node)) {
+                if (/ok|true|false|undefined|null/.test(node.name.getText())) {
+                    const expectInvocation = ChaiUtils.getExpectInvocation(node);
+                    if (!expectInvocation || expectInvocation.arguments.length !== 2) {
+                        ctx.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING);
+                    }
                 }
             }
         }
-        super.visitPropertyAccessExpression(node);
-    }
 
-    protected visitCallExpression(node: ts.CallExpression): void {
-        if (ChaiUtils.isExpectInvocation(node)) {
-            if (node.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                if (ChaiUtils.isEqualsInvocation(<ts.PropertyAccessExpression>node.expression)) {
-                    if (node.arguments.length === 1) {
-                        if (/true|false|null|undefined/.test(node.arguments[0].getText())) {
-                            this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING);
+        if (tsutils.isCallExpression(node)) {
+            if (ChaiUtils.isExpectInvocation(node)) {
+                if (tsutils.isPropertyAccessExpression(node.expression)) {
+                    if (ChaiUtils.isEqualsInvocation(node.expression)) {
+                        if (node.arguments.length === 1) {
+                            if (/true|false|null|undefined/.test(node.arguments[0].getText())) {
+                                ctx.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING);
+                            }
+                        }
+                    }
+                }
+
+                const actualValue = ChaiUtils.getFirstExpectCallParameter(node);
+                if (actualValue && tsutils.isBinaryExpression(actualValue)) {
+                    const expectedValue = ChaiUtils.getFirstExpectationParameter(node);
+                    if (expectedValue) {
+                        const operator: string = actualValue.operatorToken.getText();
+                        const expectingBooleanKeyword: boolean =
+                            expectedValue.kind === ts.SyntaxKind.TrueKeyword || expectedValue.kind === ts.SyntaxKind.FalseKeyword;
+
+                        if (operator === '===' && expectingBooleanKeyword) {
+                            ctx.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING_COMPARE_TRUE);
+                        } else if (operator === '!==' && expectingBooleanKeyword) {
+                            ctx.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING_COMPARE_FALSE);
                         }
                     }
                 }
             }
-
-            const actualValue = ChaiUtils.getFirstExpectCallParameter(node);
-            if (actualValue !== undefined && actualValue.kind === ts.SyntaxKind.BinaryExpression) {
-                const expectedValue = ChaiUtils.getFirstExpectationParameter(node);
-                if (expectedValue !== undefined) {
-                    const binaryExpression: ts.BinaryExpression = <ts.BinaryExpression>actualValue;
-                    const operator: string = binaryExpression.operatorToken.getText();
-                    const expectingBooleanKeyword: boolean =
-                        expectedValue.kind === ts.SyntaxKind.TrueKeyword || expectedValue.kind === ts.SyntaxKind.FalseKeyword;
-
-                    if (operator === '===' && expectingBooleanKeyword) {
-                        this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING_COMPARE_TRUE);
-                    } else if (operator === '!==' && expectingBooleanKeyword) {
-                        this.addFailureAt(node.getStart(), node.getWidth(), FAILURE_STRING_COMPARE_FALSE);
-                    }
-                }
-            }
         }
-        super.visitCallExpression(node);
+
+        return ts.forEachChild(node, cb);
     }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue:  #680

#### Overview of change:
Converts the `chai-vague-errors` rule to use the walk function

