### PR TITLE
convert no-control-regex rule to use walk function

### DIFF
--- a/src/noControlRegexRule.ts
+++ b/src/noControlRegexRule.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
 
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
 
@@ -21,36 +22,34 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING: string = 'Unexpected control character in regular expression';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoControlRegexRuleWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoControlRegexRuleWalker extends Lint.RuleWalker {
-    protected visitNewExpression(node: ts.NewExpression): void {
-        this.validateCall(node);
-        super.visitNewExpression(node);
-    }
-
-    protected visitCallExpression(node: ts.CallExpression): void {
-        this.validateCall(node);
-        super.visitCallExpression(node);
-    }
-
-    protected visitRegularExpressionLiteral(node: ts.Node): void {
-        if (/(\\x[0-1][0-9a-f])/.test(node.getText())) {
-            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    function cb(node: ts.Node): void {
+        if (tsutils.isNewExpression(node) || tsutils.isCallExpression(node)) {
+            validateCall(node);
         }
-        super.visitRegularExpressionLiteral(node);
+
+        if (tsutils.isRegularExpressionLiteral(node)) {
+            if (/(\\x[0-1][0-9a-f])/.test(node.getText())) {
+                ctx.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
+            }
+        }
+        return ts.forEachChild(node, cb);
     }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 
     /* tslint:disable:no-control-regex */
-    private validateCall(expression: ts.CallExpression | ts.NewExpression): void {
-        if (expression.expression.getText() === 'RegExp' && expression.arguments !== undefined && expression.arguments.length > 0) {
-            const arg1: ts.Expression = expression.arguments[0];
-            if (arg1.kind === ts.SyntaxKind.StringLiteral) {
-                const regexpText: string = (<ts.StringLiteral>arg1).text;
+    function validateCall(expression: ts.CallExpression | ts.NewExpression): void {
+        if (expression.expression.getText() === 'RegExp' && expression.arguments && expression.arguments.length > 0) {
+            const arg: ts.Expression = expression.arguments[0];
+            if (tsutils.isStringLiteral(arg)) {
+                const regexpText: string = arg.text;
                 if (/[\x00-\x1f]/.test(regexpText)) {
-                    this.addFailureAt(arg1.getStart(), arg1.getWidth(), Rule.FAILURE_STRING);
+                    ctx.addFailureAt(arg.getStart(), arg.getWidth(), Rule.FAILURE_STRING);
                 }
             }
         }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: #680
-   [x] New feature, bugfix, or enhancement

#### Overview of change:
Converts `no-control-regex` rule to use walk function
