### PR TITLE
exclude specific input types from react-a11y-input-elements rule

### DIFF
--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -48,18 +48,18 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function isExcludedInputType(node: ts.JsxSelfClosingElement): boolean {
     let isExcludedType = false;
-    node.attributes.properties.forEach(
-        (attribute: ts.JsxAttributeLike): void => {
-            if (attribute.kind === ts.SyntaxKind.JsxAttribute) {
-                if (attribute.initializer !== undefined && attribute.initializer.kind === ts.SyntaxKind.JsxExpression) {
-                    const attributeText: string = (<ts.StringLiteral>(<ts.JsxAttribute>attribute).initializer).text;
-                    if (EXCLUDED_INPUT_TYPES.indexOf(attributeText) !== -1) {
-                        isExcludedType = true;
-                    }
+
+    for (const attribute of node.attributes.properties) {
+        if (tsutils.isJsxAttribute(attribute)) {
+            if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
+                const attributeText = attribute.initializer.text;
+                if (EXCLUDED_INPUT_TYPES.indexOf(attributeText) !== -1) {
+                    isExcludedType = true;
+                    return isExcludedType;
                 }
             }
         }
-    );
+    }
     return isExcludedType;
 }
 
@@ -73,7 +73,7 @@ function walk(ctx: Lint.WalkContext<void>) {
                 if (isEmpty(attributes.value) && isEmpty(attributes.placeholder)) {
                     ctx.addFailureAt(node.getStart(), node.getWidth(), MISSING_PLACEHOLDER_INPUT_FAILURE_STRING);
                 }
-            } else if (tagName === 'textarea' && !isExcludedInputType(node)) {
+            } else if (tagName === 'textarea') {
                 const attributes = getJsxAttributesFromJsxElement(node);
                 if (isEmpty(attributes.placeholder)) {
                     ctx.addFailureAt(node.getStart(), node.getWidth(), MISSING_PLACEHOLDER_TEXTAREA_FAILURE_STRING);

--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -46,10 +46,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-function isExcludedInputType(node: ts.JsxSelfClosingElement): boolean {
+function isExcludedInputType(node: ts.JsxSelfClosingElement, attributes: { [propName: string]: ts.JsxAttribute }): boolean {
     for (const attribute of node.attributes.properties) {
         if (tsutils.isJsxAttribute(attribute)) {
-            const isInputAttributeType = getJsxAttributesFromJsxElement(node).type;
+            const isInputAttributeType = attributes.type;
             if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
                 const attributeText = attribute.initializer.text;
                 if (isInputAttributeType !== undefined && EXCLUDED_INPUT_TYPES.indexOf(attributeText) !== -1) {
@@ -68,8 +68,9 @@ function walk(ctx: Lint.WalkContext<void>) {
 
             if (tagName === 'input') {
                 const attributes = getJsxAttributesFromJsxElement(node);
-                const isExcludedInputTypeValueEmpty = isEmpty(attributes.value) && isExcludedInputType(node);
-                const isPlaceholderEmpty = isEmpty(attributes.placeholder) && !isExcludedInputType(node);
+                const isExcludedInput = isExcludedInputType(node, attributes);
+                const isExcludedInputTypeValueEmpty = isEmpty(attributes.value) && isExcludedInput;
+                const isPlaceholderEmpty = isEmpty(attributes.placeholder) && !isExcludedInput;
                 if ((isEmpty(attributes.value) && isPlaceholderEmpty) || isExcludedInputTypeValueEmpty) {
                     ctx.addFailureAt(node.getStart(), node.getWidth(), MISSING_PLACEHOLDER_INPUT_FAILURE_STRING);
                 }

--- a/src/tests/ReactA11yInputElementsRuleTests.ts
+++ b/src/tests/ReactA11yInputElementsRuleTests.ts
@@ -20,10 +20,21 @@ describe('reactA11yInputElementsRule', (): void => {
         TestHelper.assertViolations(ruleName, script, []);
     });
 
+    it('should pass on input elements without placeholder of type radio, checkbox, file', (): void => {
+        const script: string = `
+            import React = require('react');
+            const a = <input type="radio" />;
+            const b = <input type="checkbox" />;
+            const c = <input type="file" />;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, []);
+    });
+
     it('should fail on empty input elements without placeholder', (): void => {
         const script: string = `
             import React = require('react');
-            const a = <input />;
+            const a = <input type="button" />;
             const b = <textarea />;
             const c = <textarea></textarea>;
         `;

--- a/src/tests/ReactA11yInputElementsRuleTests.ts
+++ b/src/tests/ReactA11yInputElementsRuleTests.ts
@@ -23,12 +23,72 @@ describe('reactA11yInputElementsRule', (): void => {
     it('should pass on input elements without placeholder of type radio, checkbox, file', (): void => {
         const script: string = `
             import React = require('react');
+            const a = <input type="radio" value="foo" />;
+            const b = <input type="checkbox" value="foo" />;
+            const c = <input type="file" value="foo" />;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, []);
+    });
+
+    it('should fail on input elements without value of type radio, checkbox, file', (): void => {
+        const script: string = `
+            import React = require('react');
             const a = <input type="radio" />;
             const b = <input type="checkbox" />;
             const c = <input type="file" />;
         `;
 
-        TestHelper.assertViolations(ruleName, script, []);
+        TestHelper.assertViolations(ruleName, script, [
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 3 }
+            },
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 4 }
+            },
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 5 }
+            }
+        ]);
+    });
+
+    it('should fail on input elements without placeholder, when attribute is not type', (): void => {
+        const script: string = `
+            import React = require('react');
+            const a = <input foo="radio" />;
+            const b = <input bar="checkbox" />;
+            const c = <input baz="file" />;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, [
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 3 }
+            },
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 4 }
+            },
+            {
+                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
+                name: Utils.absolutePath('file.tsx'),
+                ruleName: 'react-a11y-input-elements',
+                startPosition: { character: 23, line: 5 }
+            }
+        ]);
     });
 
     it('should fail on empty input elements without placeholder', (): void => {


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #749
-   [ ] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:
Excludes the 3 input types listed in issue from requiring a placeholder.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->
