### PR TITLE
Added extra debug launch properties to allow debugging of rule tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,11 @@
             "name": "Run TSLint Tests",
             "program": "${workspaceFolder}/node_modules/tslint/bin/tslint",
             "args": ["--test", "-r", "dist/src", "tests/**"],
-            "outputCapture": "std"
+            "outputCapture": "std",
+            "sourceMaps": true,
+            "outFiles": ["${workspaceRoot}/dist/src/**/*.js"],
+            "cwd": "${workspaceFolder}",
+            "runtimeArgs": ["--nolazy"]
         }
     ]
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #703
-   [x] New feature, bugfix, or enhancement
    -   ~~Includes tests~~
-   ~~Documentation update~~

#### Overview of change:

Added `sourceMaps`, `outFiles`, `cwd` and `runtimeArgs` to the launch config for debugging rules. `outFiles` seems to be the key to getting it working. The others are included because [tslint uses them as well](https://github.com/palantir/tslint/blob/47a72189546784a7c9a49cee9002060b744c05b0/.vscode/launch.json#L42-L60).