### PR TITLE
convert no-multiline-string rule to use a walk function

### DIFF
--- a/src/noMultilineStringRule.ts
+++ b/src/noMultilineStringRule.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
+import { isNoSubstitutionTemplateLiteral } from 'tsutils';
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -23,18 +24,21 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING: string = 'Forbidden Multiline string: ';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoMultilineStringWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoMultilineStringWalker extends Lint.RuleWalker {
-    protected visitNode(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
+function walk(ctx: Lint.WalkContext<void>) {
+    function cb(node: ts.Node): void {
+        if (isNoSubstitutionTemplateLiteral(node)) {
             const fullText: string = node.getFullText();
             const firstLine: string = fullText.substring(0, fullText.indexOf('\n'));
             const trimmed: string = firstLine.substring(0, 40).trim();
-            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING + trimmed + '...');
+            ctx.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING + trimmed + '...');
         }
-        super.visitNode(node);
+
+        return ts.forEachChild(node, cb);
     }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: #680
-   [x] New feature, bugfix, or enhancement

#### Overview of change:
Converts `no-multiline-string` rule to use a walk function

