### PR TITLE
convert missing-jsdoc rule to use a walk function

### DIFF
--- a/src/missingJsdocRule.ts
+++ b/src/missingJsdocRule.ts
@@ -1,7 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
-//import { isSourceFile } from 'tsutils';
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
 
 export class Rule extends Lint.Rules.AbstractRule {


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: #680
-   [x] New feature, bugfix, or enhancement


#### Overview of change:
Converts `missing-jsdoc` rule to use a walk function

