### PR TITLE
convert max-func-body-length rule to use a walk function

### DIFF
--- a/src/maxFuncBodyLengthRule.ts
+++ b/src/maxFuncBodyLengthRule.ts
@@ -1,10 +1,22 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+
 import { AstUtils } from './utils/AstUtils';
 import { Utils } from './utils/Utils';
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
-import { forEachTokenWithTrivia } from 'tsutils';
 import { isObject } from './utils/TypeGuard';
+
+interface Options {
+    maxBodyLength: number;
+    maxFuncBodyLength: number;
+    maxFuncExpressionBodyLength: number;
+    maxArrowBodyLength: number;
+    maxMethodBodyLength: number;
+    maxCtorBodyLength: number;
+    ignoreComments: boolean;
+    ignoreParametersToFunctionRegex: RegExp;
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: ExtendedMetadata = {
@@ -24,7 +36,51 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new MaxFunctionBodyLengthRuleWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk, this.parseOptions(this.getOptions()));
+    }
+
+    private parseOptions(options: Lint.IOptions): Options {
+        let maxBodyLength!: number;
+        let maxFuncBodyLength!: number;
+        let maxFuncExpressionBodyLength!: number;
+        let maxArrowBodyLength!: number;
+        let maxMethodBodyLength!: number;
+        let maxCtorBodyLength!: number;
+        let ignoreComments!: boolean;
+        let ignoreParametersToFunctionRegex!: RegExp;
+
+        if (options.ruleArguments instanceof Array) {
+            options.ruleArguments.forEach((opt: unknown) => {
+                if (typeof opt === 'number') {
+                    maxBodyLength = opt;
+                    return;
+                }
+
+                if (isObject(opt)) {
+                    maxFuncBodyLength = <number>opt[FUNC_BODY_LENGTH];
+                    maxFuncExpressionBodyLength = <number>opt[FUNC_EXPRESSION_BODY_LENGTH];
+                    maxArrowBodyLength = <number>opt[ARROW_BODY_LENGTH];
+                    maxMethodBodyLength = <number>opt[METHOD_BODY_LENGTH];
+                    maxCtorBodyLength = <number>opt[CTOR_BODY_LENGTH];
+                    ignoreComments = !!opt[IGNORE_COMMENTS];
+                    const regex: string = <string>opt[IGNORE_PARAMETERS_TO_FUNCTION];
+                    if (regex) {
+                        ignoreParametersToFunctionRegex = new RegExp(regex);
+                    }
+                }
+            });
+        }
+
+        return {
+            maxBodyLength,
+            maxFuncBodyLength,
+            maxFuncExpressionBodyLength,
+            maxArrowBodyLength,
+            maxMethodBodyLength,
+            maxCtorBodyLength,
+            ignoreComments,
+            ignoreParametersToFunctionRegex
+        };
     }
 }
 
@@ -36,94 +92,32 @@ const CTOR_BODY_LENGTH = 'ctor-body-length';
 const IGNORE_PARAMETERS_TO_FUNCTION = 'ignore-parameters-to-function-regex';
 const IGNORE_COMMENTS = 'ignore-comments';
 
-class MaxFunctionBodyLengthRuleWalker extends Lint.RuleWalker {
-    private maxBodyLength!: number;
-    private maxFuncBodyLength!: number;
-    private maxFuncExpressionBodyLength!: number;
-    private maxArrowBodyLength!: number;
-    private maxMethodBodyLength!: number;
-    private maxCtorBodyLength!: number;
-    private ignoreComments!: boolean;
-    private currentClassName: string | undefined;
-    private ignoreParametersToFunctionRegex!: RegExp;
-    private ignoreNodes: ts.Node[] = [];
+function walk(ctx: Lint.WalkContext<Options>) {
+    const {
+        maxBodyLength,
+        maxFuncBodyLength,
+        maxFuncExpressionBodyLength,
+        maxArrowBodyLength,
+        maxMethodBodyLength,
+        maxCtorBodyLength,
+        ignoreComments,
+        ignoreParametersToFunctionRegex
+    } = ctx.options;
 
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
-        super(sourceFile, options);
-        this.parseOptions();
-    }
+    const ignoreNodes: ts.Node[] = [];
+    let currentClassName: string | undefined;
 
-    protected visitCallExpression(node: ts.CallExpression): void {
-        const functionName = AstUtils.getFunctionName(node);
-        if (this.ignoreParametersToFunctionRegex && this.ignoreParametersToFunctionRegex.test(functionName)) {
-            // temporarily store a list of ignored references
-            node.arguments.forEach(
-                (argument: ts.Expression): void => {
-                    this.ignoreNodes.push(argument);
-                }
-            );
-            super.visitCallExpression(node);
-            // clear the list of ignored references
-            this.ignoreNodes = Utils.removeAll(this.ignoreNodes, node.arguments);
-        } else {
-            super.visitCallExpression(node);
-        }
-    }
-
-    protected visitArrowFunction(node: ts.ArrowFunction): void {
-        this.validate(node);
-        super.visitArrowFunction(node);
-    }
-
-    protected visitMethodDeclaration(node: ts.MethodDeclaration): void {
-        this.validate(node);
-        super.visitMethodDeclaration(node);
-    }
-
-    protected visitFunctionDeclaration(node: ts.FunctionDeclaration): void {
-        this.validate(node);
-        super.visitFunctionDeclaration(node);
-    }
-
-    protected visitFunctionExpression(node: ts.FunctionExpression): void {
-        this.validate(node);
-        super.visitFunctionExpression(node);
-    }
-
-    protected visitConstructorDeclaration(node: ts.ConstructorDeclaration): void {
-        this.validate(node);
-        super.visitConstructorDeclaration(node);
-    }
-
-    protected visitClassDeclaration(node: ts.ClassDeclaration): void {
-        this.currentClassName = (node.name && node.name.text) || 'default';
-        super.visitClassDeclaration(node);
-        this.currentClassName = undefined;
-    }
-
-    private validate(node: ts.FunctionLikeDeclaration): void {
-        if (!Utils.contains(this.ignoreNodes, node)) {
-            let bodyLength = this.calcBodyLength(node);
-            if (this.ignoreComments) {
-                bodyLength -= this.calcBodyCommentLength(node);
-            }
-            if (this.isFunctionTooLong(node.kind, bodyLength)) {
-                this.addFuncBodyTooLongFailure(node, bodyLength);
-            }
-        }
-    }
-
-    private calcBodyLength(node: ts.FunctionLikeDeclaration) {
+    function calcBodyLength(node: ts.FunctionLikeDeclaration) {
         if (node.body === undefined) {
             return 0;
         }
-        const sourceFile: ts.SourceFile = this.getSourceFile();
+        const sourceFile: ts.SourceFile = ctx.sourceFile;
         const startLine: number = sourceFile.getLineAndCharacterOfPosition(node.body.pos).line;
         const endLine: number = sourceFile.getLineAndCharacterOfPosition(node.body.end).line;
         return endLine - startLine + 1;
     }
 
-    private calcBodyCommentLength(node: ts.FunctionLikeDeclaration) {
+    function calcBodyCommentLength(node: ts.FunctionLikeDeclaration) {
         let commentLineCount = 0;
 
         commentLineCount += node
@@ -133,7 +127,7 @@ class MaxFunctionBodyLengthRuleWalker extends Lint.RuleWalker {
                 return line.trim().match(/^\/\//) !== null;
             }).length;
 
-        forEachTokenWithTrivia(node, (text, tokenSyntaxKind) => {
+        tsutils.forEachTokenWithTrivia(node, (text, tokenSyntaxKind) => {
             if (tokenSyntaxKind === ts.SyntaxKind.MultiLineCommentTrivia) {
                 commentLineCount += text.split(/\n/).length;
             }
@@ -142,86 +136,114 @@ class MaxFunctionBodyLengthRuleWalker extends Lint.RuleWalker {
         return commentLineCount;
     }
 
-    private isFunctionTooLong(nodeKind: ts.SyntaxKind, length: number): boolean {
-        return length > this.getMaxLength(nodeKind);
+    function isFunctionTooLong(nodeKind: ts.SyntaxKind, length: number): boolean {
+        return length > getMaxLength(nodeKind);
     }
 
-    private parseOptions() {
-        this.getOptions().forEach((opt: unknown) => {
-            if (typeof opt === 'number') {
-                this.maxBodyLength = opt;
-                return;
-            }
+    function getMaxLength(nodeKind: ts.SyntaxKind) {
+        let result: number;
+        switch (nodeKind) {
+            case ts.SyntaxKind.FunctionDeclaration:
+                result = maxFuncBodyLength;
+                break;
+            case ts.SyntaxKind.FunctionExpression:
+                result = maxFuncExpressionBodyLength;
+                break;
+            case ts.SyntaxKind.MethodDeclaration:
+                result = maxMethodBodyLength;
+                break;
+            case ts.SyntaxKind.ArrowFunction:
+                result = maxArrowBodyLength;
+                break;
+            case ts.SyntaxKind.Constructor:
+                result = maxCtorBodyLength;
+                break;
+            default:
+                throw new Error(`Unsupported node kind: ${nodeKind}`);
+        }
 
-            if (isObject(opt)) {
-                this.maxFuncBodyLength = <number>opt[FUNC_BODY_LENGTH];
-                this.maxFuncExpressionBodyLength = <number>opt[FUNC_EXPRESSION_BODY_LENGTH];
-                this.maxArrowBodyLength = <number>opt[ARROW_BODY_LENGTH];
-                this.maxMethodBodyLength = <number>opt[METHOD_BODY_LENGTH];
-                this.maxCtorBodyLength = <number>opt[CTOR_BODY_LENGTH];
-                this.ignoreComments = !!opt[IGNORE_COMMENTS];
-                const regex: string = <string>opt[IGNORE_PARAMETERS_TO_FUNCTION];
-                if (regex) {
-                    this.ignoreParametersToFunctionRegex = new RegExp(regex);
-                }
-            }
-        });
+        return result || maxBodyLength;
     }
 
-    private addFuncBodyTooLongFailure(node: ts.FunctionLikeDeclaration, length: number) {
-        this.addFailureAt(node.getStart(), node.getWidth(), this.formatFailureText(node, length));
+    function addFuncBodyTooLongFailure(node: ts.FunctionLikeDeclaration, length: number) {
+        ctx.addFailureAt(node.getStart(), node.getWidth(), formatFailureText(node, length));
     }
 
-    private formatFailureText(node: ts.FunctionLikeDeclaration, length: number) {
-        const funcTypeText: string = this.getFuncTypeText(node.kind);
-        const maxLength: number = this.getMaxLength(node.kind);
-        const placeText: string = this.formatPlaceText(node);
+    function formatFailureText(node: ts.FunctionLikeDeclaration, length: number) {
+        const funcTypeText: string = getFuncTypeText(node.kind);
+        const maxLength: number = getMaxLength(node.kind);
+        const placeText: string = formatPlaceText(node);
         return `Max ${funcTypeText} body length exceeded${placeText} - max: ${maxLength}, actual: ${length}`;
     }
 
-    private formatPlaceText(node: ts.FunctionLikeDeclaration) {
-        const funcTypeText = this.getFuncTypeText(node.kind);
+    function formatPlaceText(node: ts.FunctionLikeDeclaration) {
+        const funcTypeText = getFuncTypeText(node.kind);
         if (ts.isMethodDeclaration(node) || ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) {
             return ` in ${funcTypeText} ${node.name ? node.name.getText() : ''}()`;
         } else if (node.kind === ts.SyntaxKind.Constructor) {
-            return ` in class ${this.currentClassName}`;
+            return ` in class ${currentClassName}`;
         }
         return '';
     }
 
-    private getFuncTypeText(nodeKind: ts.SyntaxKind) {
-        if (nodeKind === ts.SyntaxKind.FunctionDeclaration) {
-            return 'function';
-        } else if (nodeKind === ts.SyntaxKind.FunctionExpression) {
-            return 'function expression';
-        } else if (nodeKind === ts.SyntaxKind.MethodDeclaration) {
-            return 'method';
-        } else if (nodeKind === ts.SyntaxKind.ArrowFunction) {
-            return 'arrow function';
-        } else if (nodeKind === ts.SyntaxKind.Constructor) {
-            return 'constructor';
-        } else {
-            throw new Error(`Unsupported node kind: ${nodeKind}`);
+    function getFuncTypeText(nodeKind: ts.SyntaxKind) {
+        switch (nodeKind) {
+            case ts.SyntaxKind.FunctionDeclaration:
+                return 'function';
+            case ts.SyntaxKind.FunctionExpression:
+                return 'function expression';
+            case ts.SyntaxKind.MethodDeclaration:
+                return 'method';
+            case ts.SyntaxKind.ArrowFunction:
+                return 'arrow function';
+            case ts.SyntaxKind.Constructor:
+                return 'constructor';
+            default:
+                throw new Error(`Unsupported node kind: ${nodeKind}`);
         }
     }
 
-    private getMaxLength(nodeKind: ts.SyntaxKind) {
-        let result: number;
+    function validate(node: ts.FunctionLikeDeclaration): void {
+        if (!Utils.contains(ignoreNodes, node)) {
+            let bodyLength = calcBodyLength(node);
+            if (ignoreComments) {
+                bodyLength -= calcBodyCommentLength(node);
+            }
+            if (isFunctionTooLong(node.kind, bodyLength)) {
+                addFuncBodyTooLongFailure(node, bodyLength);
+            }
+        }
+    }
 
-        if (nodeKind === ts.SyntaxKind.FunctionDeclaration) {
-            result = this.maxFuncBodyLength;
-        } else if (nodeKind === ts.SyntaxKind.FunctionExpression) {
-            result = this.maxFuncExpressionBodyLength;
-        } else if (nodeKind === ts.SyntaxKind.MethodDeclaration) {
-            result = this.maxMethodBodyLength;
-        } else if (nodeKind === ts.SyntaxKind.ArrowFunction) {
-            result = this.maxArrowBodyLength;
-        } else if (nodeKind === ts.SyntaxKind.Constructor) {
-            result = this.maxCtorBodyLength;
-        } else {
-            throw new Error(`Unsupported node kind: ${nodeKind}`);
+    function cb(node: ts.Node): void {
+        if (tsutils.isCallExpression(node)) {
+            const functionName = AstUtils.getFunctionName(node);
+            if (ignoreParametersToFunctionRegex && ignoreParametersToFunctionRegex.test(functionName)) {
+                // temporarily store a list of ignored references
+                node.arguments.forEach(
+                    (argument: ts.Expression): void => {
+                        ignoreNodes.push(argument);
+                    }
+                );
+            }
         }
 
-        return result || this.maxBodyLength;
+        if (
+            tsutils.isArrowFunction(node) ||
+            tsutils.isMethodDeclaration(node) ||
+            tsutils.isFunctionDeclaration(node) ||
+            tsutils.isFunctionExpression(node) ||
+            tsutils.isConstructorDeclaration(node)
+        ) {
+            validate(node);
+        }
+
+        if (tsutils.isClassDeclaration(node)) {
+            currentClassName = (node.name && node.name.text) || 'default';
+        }
+
+        return ts.forEachChild(node, cb);
     }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue:  #680
-   [x] New feature, bugfix, or enhancement

#### Overview of change:
Converts `max-func-body-length` rule to use a walk function

