### PR TITLE
convert no-unsupported-browser-code rule to use a walk function

### DIFF
--- a/src/noUnsupportedBrowserCodeRule.ts
+++ b/src/noUnsupportedBrowserCodeRule.ts
@@ -16,6 +16,10 @@ interface BrowserVersion {
     version: number | string;
 }
 
+interface Options {
+    readonly supportedBrowsers: { [key: string]: BrowserVersion };
+}
+
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: ExtendedMetadata = {
         ruleName: 'no-unsupported-browser-code',
@@ -32,85 +36,66 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoUnsupportedBrowserCodeRuleWalker(sourceFile, this.getOptions()));
-    }
-}
-
-class NoUnsupportedBrowserCodeRuleWalker extends Lint.RuleWalker {
-    private readonly supportedBrowsers: { [key: string]: BrowserVersion };
-
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
-        super(sourceFile, options);
-        this.supportedBrowsers = this.parseSupportedBrowsers();
+        return this.applyWithFunction(sourceFile, walk, this.parseSupportedBrowsers(this.getOptions()));
     }
 
-    protected visitSourceFile(node: ts.SourceFile): void {
-        // do not call super.visitSourceFile because we're already scanning the full file below
-
-        forEachTokenWithTrivia(node, (text, tokenSyntaxKind, range) => {
-            let regex;
-            if (tokenSyntaxKind === ts.SyntaxKind.MultiLineCommentTrivia) {
-                regex = new RegExp(`${JSDOC_BROWSERSPECIFIC}\\s*(.*)`, 'gi');
-            } else if (tokenSyntaxKind === ts.SyntaxKind.SingleLineCommentTrivia) {
-                regex = new RegExp(`${COMMENT_BROWSERSPECIFIC}\\s*(.*)`, 'gi');
-            } else {
-                return;
-            }
-
-            let match;
-            const tokenText = text.substring(range.pos, range.end);
-            // tslint:disable-next-line:no-conditional-assignment
-            while ((match = regex.exec(tokenText))) {
-                const browser = this.parseBrowserString(match[1]);
-                if (browser === undefined) {
-                    break;
-                }
-
-                this.findUnsupportedBrowserFailures(browser, range.pos, range.end - range.pos);
-            }
-        });
-    }
-
-    private parseBrowserString(browser: string): BrowserVersion | undefined {
-        // This case-insensitive regex contains 3 capture groups:
-        //     #1 looks for a browser name (combination of spaces and alpha)
-        //     #2 looks for an optional comparison operator (>=, <=, etc)
-        //     #3 looks for a version number
-        const regex = /([a-zA-Z ]*)(>=|<=|<|>)?\s*(\d*)/i;
-        const match = browser.match(regex);
-        if (match === null) {
-            return undefined;
-        }
-
-        return {
-            name: match[1].trim(),
-            comparison: match[2] || '=',
-            version: parseInt(match[3], 10) || UNSPECIFIED_BROWSER_VERSION
-        };
-    }
-
-    private parseSupportedBrowsers(): { [key: string]: BrowserVersion } {
+    private parseSupportedBrowsers(options: Lint.IOptions): Options {
         const result: { [key: string]: BrowserVersion } = {};
 
-        this.getOptions().forEach((option: unknown) => {
+        const ruleArguments: unknown[] = options.ruleArguments;
+
+        (ruleArguments || []).forEach((option: unknown) => {
             if (option instanceof Array) {
                 option.forEach((browserString: string) => {
-                    const browser = this.parseBrowserString(browserString);
+                    const browser = parseBrowserString(browserString);
                     if (browser !== undefined) {
                         result[browser.name.toLowerCase()] = browser;
                     }
                 });
             }
         });
-        return result;
+
+        return {
+            supportedBrowsers: result
+        };
+    }
+}
+
+function parseBrowserString(browser: string): BrowserVersion | undefined {
+    // This case-insensitive regex contains 3 capture groups:
+    //     #1 looks for a browser name (combination of spaces and alpha)
+    //     #2 looks for an optional comparison operator (>=, <=, etc)
+    //     #3 looks for a version number
+    const regex = /([a-zA-Z ]*)(>=|<=|<|>)?\s*(\d*)/i;
+    const match = browser.match(regex);
+    if (match === null) {
+        return undefined;
     }
 
-    private isSupportedBrowser(targetBrowser: BrowserVersion): boolean {
-        return targetBrowser.name.toLowerCase() in this.supportedBrowsers;
+    return {
+        name: match[1].trim(),
+        comparison: match[2] || '=',
+        version: parseInt(match[3], 10) || UNSPECIFIED_BROWSER_VERSION
+    };
+}
+
+function walk(ctx: Lint.WalkContext<Options>) {
+    const { supportedBrowsers } = ctx.options;
+
+    function findUnsupportedBrowserFailures(targetBrowser: BrowserVersion, startPos: number, length: number) {
+        if (!isSupportedBrowser(targetBrowser)) {
+            ctx.addFailureAt(startPos, length, `${FAILURE_BROWSER_STRING}: ${targetBrowser.name}`);
+        } else if (!isSupportedBrowserVersion(targetBrowser)) {
+            ctx.addFailureAt(startPos, length, `${FAILURE_VERSION_STRING}: ${targetBrowser.name} ${targetBrowser.version}`);
+        }
     }
 
-    private isSupportedBrowserVersion(targetBrowser: BrowserVersion): boolean {
-        const supportedBrowser = this.supportedBrowsers[targetBrowser.name.toLowerCase()];
+    function isSupportedBrowser(targetBrowser: BrowserVersion): boolean {
+        return targetBrowser.name.toLowerCase() in supportedBrowsers;
+    }
+
+    function isSupportedBrowserVersion(targetBrowser: BrowserVersion): boolean {
+        const supportedBrowser = supportedBrowsers[targetBrowser.name.toLowerCase()];
 
         if (supportedBrowser.version === UNSPECIFIED_BROWSER_VERSION) {
             // If the supplied browser supports every version (aka unspecified
@@ -134,11 +119,30 @@ class NoUnsupportedBrowserCodeRuleWalker extends Lint.RuleWalker {
         }
     }
 
-    private findUnsupportedBrowserFailures(targetBrowser: BrowserVersion, startPos: number, length: number) {
-        if (!this.isSupportedBrowser(targetBrowser)) {
-            this.addFailureAt(startPos, length, `${FAILURE_BROWSER_STRING}: ${targetBrowser.name}`);
-        } else if (!this.isSupportedBrowserVersion(targetBrowser)) {
-            this.addFailureAt(startPos, length, `${FAILURE_VERSION_STRING}: ${targetBrowser.name} ${targetBrowser.version}`);
-        }
+    function cb(node: ts.Node): void {
+        forEachTokenWithTrivia(node, (text, tokenSyntaxKind, range) => {
+            let regex;
+            if (tokenSyntaxKind === ts.SyntaxKind.MultiLineCommentTrivia) {
+                regex = new RegExp(`${JSDOC_BROWSERSPECIFIC}\\s*(.*)`, 'gi');
+            } else if (tokenSyntaxKind === ts.SyntaxKind.SingleLineCommentTrivia) {
+                regex = new RegExp(`${COMMENT_BROWSERSPECIFIC}\\s*(.*)`, 'gi');
+            } else {
+                return;
+            }
+
+            let match;
+            const tokenText = text.substring(range.pos, range.end);
+            // tslint:disable-next-line:no-conditional-assignment
+            while ((match = regex.exec(tokenText))) {
+                const browser = parseBrowserString(match[1]);
+                if (browser === undefined) {
+                    break;
+                }
+
+                findUnsupportedBrowserFailures(browser, range.pos, range.end - range.pos);
+            }
+        });
     }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: #680
-   [x] New feature, bugfix, or enhancement


#### Overview of change:
Converts `no-unsupported-browser-code` rule to use a walk function

