### PR TITLE
convert no-unexternalized-strings rule to use a walk function

### DIFF
--- a/src/noUnexternalizedStringsRule.ts
+++ b/src/noUnexternalizedStringsRule.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
 
 import { ExtendedMetadata } from './utils/ExtendedMetadata';
 
@@ -20,7 +21,36 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoUnexternalizedStringsRuleWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk, this.parseOptions(this.getOptions()));
+    }
+
+    private parseOptions(options: Lint.IOptions): Options {
+        let messageIndex: number | undefined;
+        /* tslint:disable:no-null-keyword */
+        const signatures: Map<boolean> = Object.create(null);
+        const ignores: Map<boolean> = Object.create(null);
+        /* tslint:enable:no-null-keyword */
+
+        if (options.ruleArguments instanceof Array) {
+            const args = options.ruleArguments.length > 0 ? options.ruleArguments[0] : undefined;
+            if (args) {
+                if (Array.isArray(args.signatures)) {
+                    args.signatures.forEach((signature: string) => (signatures[signature] = true));
+                }
+                if (Array.isArray(args.ignores)) {
+                    args.ignores.forEach((ignore: string) => (ignores[ignore] = true));
+                }
+                if (args.messageIndex !== undefined) {
+                    messageIndex = args.messageIndex;
+                }
+            }
+        }
+
+        return {
+            signatures,
+            messageIndex,
+            ignores
+        };
     }
 }
 
@@ -28,74 +58,47 @@ interface Map<V> {
     [key: string]: V;
 }
 
-interface UnexternalizedStringsOptions {
-    signatures?: string[];
-    messageIndex?: number;
-    ignores?: string[];
+interface Options {
+    readonly signatures: Map<boolean>;
+    readonly messageIndex: number | undefined;
+    readonly ignores: Map<boolean>;
 }
 
-class NoUnexternalizedStringsRuleWalker extends Lint.RuleWalker {
-    private static readonly SINGLE_QUOTE: string = "'";
+type DescribingParent = {
+    callInfo?: {
+        callExpression: ts.CallExpression;
+        argIndex: number;
+    };
+    ignoreUsage?: boolean;
+};
 
-    private readonly signatures: Map<boolean>;
-    private readonly messageIndex: number | undefined;
-    private readonly ignores: Map<boolean>;
+function walk(ctx: Lint.WalkContext<Options>) {
+    const SINGLE_QUOTE: string = `'`;
+    const { signatures, messageIndex, ignores } = ctx.options;
 
-    constructor(sourceFile: ts.SourceFile, opt: Lint.IOptions) {
-        super(sourceFile, opt);
-
-        /* tslint:disable:no-null-keyword */
-        this.signatures = Object.create(null);
-        this.ignores = Object.create(null);
-        /* tslint:enable:no-null-keyword */
-
-        const options: unknown = this.getOptions();
-        const first: UnexternalizedStringsOptions = options && Array.isArray(options) && options.length > 0 ? options[0] : undefined;
-        if (first) {
-            if (Array.isArray(first.signatures)) {
-                first.signatures.forEach((signature: string) => (this.signatures[signature] = true));
-            }
-            if (Array.isArray(first.ignores)) {
-                first.ignores.forEach((ignore: string) => (this.ignores[ignore] = true));
-            }
-            if (first.messageIndex !== undefined) {
-                this.messageIndex = first.messageIndex;
-            }
-        }
-    }
-
-    protected visitStringLiteral(node: ts.StringLiteral): void {
-        this.checkStringLiteral(node);
-        super.visitStringLiteral(node);
-    }
-
-    private checkStringLiteral(node: ts.StringLiteral): void {
+    function checkStringLiteral(node: ts.StringLiteral): void {
         const text = node.getText();
         // The string literal is enclosed in single quotes. Treat as OK.
-        if (
-            text.length >= 2 &&
-            text[0] === NoUnexternalizedStringsRuleWalker.SINGLE_QUOTE &&
-            text[text.length - 1] === NoUnexternalizedStringsRuleWalker.SINGLE_QUOTE
-        ) {
+        if (text.length >= 2 && text[0] === SINGLE_QUOTE && text[text.length - 1] === SINGLE_QUOTE) {
             return;
         }
-        const info = this.findDescribingParent(node);
+        const info = findDescribingParent(node);
         // Ignore strings in import and export nodes.
         if (info && info.ignoreUsage) {
             return;
         }
         const callInfo = info ? info.callInfo : undefined;
-        if (callInfo && this.ignores[callInfo.callExpression.expression.getText()]) {
+        if (callInfo && ignores[callInfo.callExpression.expression.getText()]) {
             return;
         }
-        if (!callInfo || callInfo.argIndex === -1 || !this.signatures[callInfo.callExpression.expression.getText()]) {
-            this.addFailureAt(node.getStart(), node.getWidth(), `Unexternalized string found: ${node.getText()}`);
+        if (!callInfo || callInfo.argIndex === -1 || !signatures[callInfo.callExpression.expression.getText()]) {
+            ctx.addFailureAt(node.getStart(), node.getWidth(), `Unexternalized string found: ${node.getText()}`);
             return;
         }
         // We have a string that is a direct argument into the localize call.
-        const messageArg = callInfo.argIndex === this.messageIndex ? callInfo.callExpression.arguments[this.messageIndex] : undefined;
+        const messageArg = callInfo.argIndex === messageIndex ? callInfo.callExpression.arguments[messageIndex] : undefined;
         if (messageArg && messageArg !== node) {
-            this.addFailureAt(
+            ctx.addFailureAt(
                 node.getStart(),
                 node.getWidth(),
                 `Message argument to '${callInfo.callExpression.expression.getText()}' must be a string literal.`
@@ -104,40 +107,52 @@ class NoUnexternalizedStringsRuleWalker extends Lint.RuleWalker {
         }
     }
 
-    private findDescribingParent(
-        node: ts.Node
-    ): { callInfo?: { callExpression: ts.CallExpression; argIndex: number }; ignoreUsage?: boolean } | undefined {
-        const kinds = ts.SyntaxKind;
-        while (node.parent !== undefined) {
+    function findDescribingParent(node: ts.Node): DescribingParent | undefined {
+        while (node.parent) {
             const parent: ts.Node = node.parent;
-            const kind = parent.kind;
-            if (kind === kinds.CallExpression) {
-                const callExpression = <ts.CallExpression>parent;
+
+            if (tsutils.isCallExpression(parent)) {
+                const callExpression = parent;
                 return {
                     callInfo: {
-                        callExpression: callExpression,
+                        callExpression,
                         argIndex: callExpression.arguments.indexOf(<ts.Expression>node)
                     }
                 };
-            } else if (kind === kinds.ImportEqualsDeclaration || kind === kinds.ImportDeclaration || kind === kinds.ExportDeclaration) {
+            }
+
+            if (tsutils.isImportEqualsDeclaration(parent) || tsutils.isImportDeclaration(parent) || tsutils.isExportDeclaration(parent)) {
                 return { ignoreUsage: true };
-            } else if (
-                kind === kinds.VariableDeclaration ||
-                kind === kinds.FunctionDeclaration ||
-                kind === kinds.PropertyDeclaration ||
-                kind === kinds.MethodDeclaration ||
-                kind === kinds.VariableDeclarationList ||
-                kind === kinds.InterfaceDeclaration ||
-                kind === kinds.ClassDeclaration ||
-                kind === kinds.EnumDeclaration ||
-                kind === kinds.ModuleDeclaration ||
-                kind === kinds.TypeAliasDeclaration ||
-                kind === kinds.SourceFile
+            }
+
+            if (
+                tsutils.isVariableDeclaration(parent) ||
+                tsutils.isFunctionDeclaration(parent) ||
+                tsutils.isPropertyDeclaration(parent) ||
+                tsutils.isMethodDeclaration(parent) ||
+                tsutils.isVariableDeclarationList(parent) ||
+                tsutils.isInterfaceDeclaration(parent) ||
+                tsutils.isClassDeclaration(parent) ||
+                tsutils.isEnumDeclaration(parent) ||
+                tsutils.isModuleDeclaration(parent) ||
+                tsutils.isTypeAliasDeclaration(parent) ||
+                tsutils.isSourceFile(parent)
             ) {
                 return undefined;
             }
+
             node = parent;
         }
         return undefined;
     }
+
+    function cb(node: ts.Node): void {
+        if (tsutils.isStringLiteral(node)) {
+            checkStringLiteral(node);
+        }
+
+        return ts.forEachChild(node, cb);
+    }
+
+    return ts.forEachChild(ctx.sourceFile, cb);
 }


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: #680
-   [x] New feature, bugfix, or enhancement

#### Overview of change:
Converts `no-unexternalized-strings` rule to use a walk function
