### PR TITLE
Add missing `import "module-name"` test for import-name rule

### DIFF
--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -260,4 +260,15 @@ describe('importNameRule', (): void => {
 
         TestHelper.assertViolations(ruleName, script, []);
     });
+
+    it('should pass on importing modules without a name', () => {
+        const script = `
+            import 'mocha';
+            import '../../path';
+            import './polyfills';
+            import 'rxjs/add/operator/switchMap';
+        `;
+
+        TestHelper.assertViolations(ruleName, script, []);
+    });
 });


### PR DESCRIPTION
-   [x] Addresses an existing issue: fixes #671
-   [x] Enhancement
    -   [x] Includes tests

#### Overview of change:

Add missing test for importing modules without a name.


#### Is there anything you'd like reviewers to focus on?

I hope this is what is required.

<!-- optional -->