### PR TITLE
Strict order of rules in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ You can create a new rule from a template with the `create-rule` script:
 npm run create-rule
 ```
 
-This will prompt you to enter the details of the new rule. Once you're done, it will create a file for the rule implementation (inside `src`) as well as folder with rule tests (inside `test`).
+This will prompt you to enter the details of the new rule. Once you're done, it will create a file for the rule implementation (inside `src`), folder with rule tests (inside `test`), and will add rule info to `README.md`.
+
+You should update rule entry in `README.md` with information about available options, more detailed description, and examples if needed. New rules should have `@next` placeholder in version column, which will be replaced with proper version during release process.
 
 More information about writing rule tests can be found in [TSLint documentation](https://palantir.github.io/tslint/develop/testing-rules/).
 

--- a/README.md
+++ b/README.md
@@ -144,24 +144,6 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
     </tr>
     <tr>
       <td>
-        <code>react-a11y-accessible-headings</code>
-      </td>
-      <td>
-        For accessibility of your website, there should be no more than 2 H1 heading elements, HTML heading elements must be concise, used for structuring information on the page and non-empty.
-      </td>
-      <td>6.0.0</td>
-    </tr>
-    <tr>
-      <td>
-        <code>react-a11y-iframes</code>
-      </td>
-      <td>
-        Enforce that iframe elements are not empty, have title, and are unique.
-      </td>
-      <td>6.1.0</td>
-    </tr>
-    <tr>
-      <td>
         <code>informative-docs</code>
       </td>
       <td>
@@ -733,15 +715,6 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
     </tr>
     <tr>
       <td>
-        <code>void-zero</code>
-      </td>
-      <td>
-        <code>void 0</code>, which resolves to <code>undefined</code>, can be confusing to newcomers. Exclusively use <code>undefined</code> to reduce ambiguity.
-      </td>
-      <td>6.1.0</td>
-    </tr>
-    <tr>
-      <td>
         <code>no-var-self</code>
       </td>
       <td>
@@ -841,6 +814,15 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
     </tr>
     <tr>
       <td>
+        <code>react-a11y-accessible-headings</code>
+      </td>
+      <td>
+        For accessibility of your website, there should be no more than 2 H1 heading elements, HTML heading elements must be concise, used for structuring information on the page and non-empty.
+      </td>
+      <td>6.0.0</td>
+    </tr>
+    <tr>
+      <td>
         <code>react-a11y-anchors</code>
       </td>
       <td>
@@ -885,6 +867,15 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
         </ul>
       </td>
       <td>2.0.11</td>
+    </tr>
+    <tr>
+      <td>
+        <code>react-a11y-iframes</code>
+      </td>
+      <td>
+        Enforce that iframe elements are not empty, have title, and are unique.
+      </td>
+      <td>6.1.0</td>
     </tr>
     <tr>
       <td>
@@ -1006,6 +997,21 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
     </tr>
     <tr>
       <td>
+        <code>react-a11y-role</code>
+      </td>
+      <td>
+        For accessibility of your website, elements with aria roles must use a **valid**, **non-abstract** aria role.
+        A reference to role definitions can be found at [WAI-ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions).
+        <br />
+        References:
+        <ul>
+          <li><a href="http://oaa-accessibility.org/wcag20/rule/92">WCAG Rule 92: Role value must be valid</a></li>
+        </ul>
+      </td>
+      <td>2.0.11</td>
+    </tr>
+    <tr>
+      <td>
         <code>react-a11y-role-has-required-aria-props</code>
       </td>
       <td>
@@ -1035,21 +1041,6 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
           <li><a href="http://oaa-accessibility.org/wcag20/rule/87">ARIA attributes can only be used with certain roles</a></li>
           <li><a href="http://oaa-accessibility.org/wcag20/rule/84">Check aria properties and states for valid roles and properties</a></li>
           <li><a href="http://oaa-accessibility.org/wcag20/rule/93">Check that 'ARIA-' attributes are valid properties and states</a></li>
-        </ul>
-      </td>
-      <td>2.0.11</td>
-    </tr>
-    <tr>
-      <td>
-        <code>react-a11y-role</code>
-      </td>
-      <td>
-        For accessibility of your website, elements with aria roles must use a **valid**, **non-abstract** aria role.
-        A reference to role definitions can be found at [WAI-ARIA roles](https://www.w3.org/TR/wai-aria/roles#role_definitions).
-        <br />
-        References:
-        <ul>
-          <li><a href="http://oaa-accessibility.org/wcag20/rule/92">WCAG Rule 92: Role value must be valid</a></li>
         </ul>
       </td>
       <td>2.0.11</td>
@@ -1243,6 +1234,15 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
         Similar to the <a href="https://eslint.org/docs/rules/valid-typeof">valid-typeof ESLint rule</a>.
       </td>
       <td>1.0</td>
+    </tr>
+    <tr>
+      <td>
+        <code>void-zero</code>
+      </td>
+      <td>
+        <code>void 0</code>, which resolves to <code>undefined</code>, can be confusing to newcomers. Exclusively use <code>undefined</code> to reduce ambiguity.
+      </td>
+      <td>6.1.0</td>
     </tr>
   </tbody>
 </table>

--- a/build-tasks/common/readme-rules.js
+++ b/build-tasks/common/readme-rules.js
@@ -1,0 +1,22 @@
+const { readFile, writeFile } = require('./files');
+
+// Matches <tr>, <td>, and <code> openning tags with only whitespace surrounding them
+// Capturing group for rule name inside <code> and </code> tags with possible whitespace around it
+const praseRe = /\s+<tr>\s*?<td>\s*?<code>\s*?([0-9a-z-]*?)\s*?<\/code>/g;
+const README_NAME = 'README.md';
+const readmeContent = readFile(README_NAME);
+
+function getAllRules() {
+    const rules = [];
+    let match;
+
+    while ((match = praseRe.exec(readmeContent))) {
+        rules.push(match[1]);
+    }
+
+    return rules;
+}
+
+module.exports = {
+    getAllRules
+};

--- a/build-tasks/common/readme-rules.js
+++ b/build-tasks/common/readme-rules.js
@@ -17,6 +17,34 @@ function getAllRules() {
     return rules;
 }
 
+function addNewRule(name, ruleMarkup) {
+    let match;
+    let insertPosition;
+
+    while ((match = praseRe.exec(readmeContent))) {
+        const existingName = match[1];
+        // Looks for first rule that should follow new rule.
+        // Match position will be used to insert new rule row
+        if (name < existingName) {
+            insertPosition = match.index;
+            break;
+        }
+    }
+
+    // In case when new rule should be added to the end of the table - look for insret position before </tbody>
+    if (insertPosition === undefined) {
+        insertPosition = readmeContent.match(/\s+<\/tbody>\s+<\/table>/).index;
+    }
+    const contentBeforeNewRule = readmeContent.slice(0, insertPosition);
+    const contentAfterNewRule = readmeContent.slice(insertPosition);
+    const newContent = contentBeforeNewRule + ruleMarkup + contentAfterNewRule;
+    writeFile(README_NAME, newContent);
+
+    // To position cursor on the same line with new rule name should add 3 lines to match lines added with template
+    return `./${README_NAME}:${contentBeforeNewRule.split('\n').length + 3}`;
+}
+
 module.exports = {
-    getAllRules
+    getAllRules,
+    addNewRule
 };

--- a/build-tasks/create-rule.js
+++ b/build-tasks/create-rule.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const inquirer = require('inquirer');
 const path = require('path');
 const { writeFile } = require('./common/files');
+const readmeTemplate = require('./templates/readme-rule-entry.template');
+const { addNewRule } = require('./common/readme-rules');
 
 const questions = [
     {
@@ -88,13 +90,15 @@ const questions = [
 inquirer.prompt(questions).then(answers => {
     const sourceFileName = createImplementationFile(answers);
     const testFileNames = createTestFiles(answers);
+    const readmePosition = createReadmeEntry(answers);
 
     console.log(`Rule '${answers.name}' created.`);
     console.log(`Source file: ${sourceFileName}`);
-    console.log(`Test files:   ${testFileNames.join(', ')}`);
+    console.log(`Test files:   ${testFileNames.join(' ')}`);
+    console.log(`README.md entry: ${readmePosition}`);
 
     // Attempt to open the files in the current editor.
-    tryOpenFiles([...testFileNames, sourceFileName]);
+    tryOpenFiles([...testFileNames, sourceFileName, readmePosition]);
 });
 
 function createImplementationFile(answers) {
@@ -137,6 +141,11 @@ function createTestFiles(answers) {
     writeFile(lintFile, JSON.stringify(tslintContent, undefined, 4));
 
     return testFiles;
+}
+
+function createReadmeEntry(answers) {
+    const content = readmeTemplate(answers);
+    return addNewRule(answers.name, content);
 }
 
 function camelCase(input) {

--- a/build-tasks/templates/readme-rule-entry.template.js
+++ b/build-tasks/templates/readme-rule-entry.template.js
@@ -1,0 +1,8 @@
+module.exports = ({ name, description }) => `
+    <tr>
+      <td>
+        <code>${name}</code>
+      </td>
+      <td>${description}</td>
+      <td>@next</td>
+    </tr>`;

--- a/build-tasks/validate-rules-order.js
+++ b/build-tasks/validate-rules-order.js
@@ -1,0 +1,18 @@
+const { yellowBright } = require('chalk');
+const { getAllRules } = require('./common/readme-rules');
+
+const rules = getAllRules();
+const sortedRules = [].concat(rules).sort();
+const mismatchIndex = rules.findIndex((name, i) => name !== sortedRules[i]);
+
+if (mismatchIndex === -1) {
+    process.exit(0);
+}
+
+const message =
+    mismatchIndex === 0
+        ? `First rule expecteded to be ${sortedRules[0]} but found ${rules[0]}.`
+        : `Rule ${rules[mismatchIndex - 1]} should be followed by ${sortedRules[mismatchIndex]} but found ${rules[mismatchIndex]}.`;
+console.log(yellowBright('Incorrect order of rules in README.md.'));
+console.log(message);
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "tslint:check": "tslint-config-prettier-check ./tslint.json",
     "validate:config": "node build-tasks/validate-config.js",
     "validate:documentation": "node build-tasks/validate-documentation.js",
+    "validate:rules-order": "node build-tasks/validate-rules-order.js",
     "watch:run-tests": "node build-tasks/watch-run-tests.js",
     "watch:src": "tsc --watch"
   },


### PR DESCRIPTION
#### PR checklist

-   [X] Addresses an existing issue: fixes #816, fixes #648 
-   [X] New feature
    -   [ ] Includes tests
-   [X] Documentation update

#### Overview of change:
New validation is added to `npm test` that will check if rules in `REAME.md`'s table are sorted alphabetically.
Updated `create-rule` script will also add row for new rule in correct place. `@next` will be used as placeholder for version as was discussed in #648.

#### Is there anything you'd like reviewers to focus on?
I've used regular expression to work with table in `README.md` because HTML markup is pretty simple, RegExp is simple enough, and it helps to avoid adding another dependency for temporary solution (should be removed with  #575).

Also, looks like VS Code no longer sets environment variable in terminal, so files should be opened by hand.

Please check [Releases](https://github.com/Microsoft/tslint-microsoft-contrib/wiki/Releases) that was updated to mention `@next` placeholder.