### PR TITLE
Add case sensitivity to import-name rule

### DIFF
--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -101,6 +101,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 enum StringCase {
+    any = 'any-case',
     pascal = 'PascalCase',
     camel = 'camelCase'
 }
@@ -196,7 +197,11 @@ function walk(ctx: Lint.WalkContext<Option>) {
         moduleName: string,
         node: ts.ImportEqualsDeclaration | ts.ImportDeclaration
     ): boolean {
-        if (transformName(expectedImportedName) === importedName) {
+        if (option.config.case === StringCase.any) {
+            if (makeCamelCase(expectedImportedName) === importedName || makePascalCase(expectedImportedName) === importedName) {
+                return true;
+            }
+        } else if (transformName(expectedImportedName) === importedName) {
             return true;
         }
 
@@ -224,8 +229,10 @@ function walk(ctx: Lint.WalkContext<Option>) {
                 return makeCamelCase(input);
             case StringCase.pascal:
                 return makePascalCase(input);
+            case StringCase.any:
+                return `${makeCamelCase(input)} or ${makePascalCase(input)}`;
             default:
-                throw new Error(`Unknown case for import-name rule ${option.config.case}`);
+                throw new Error(`Unknown case for import-name rule: "${option.config.case}"`);
         }
     }
 

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -197,11 +197,7 @@ function walk(ctx: Lint.WalkContext<Option>) {
         moduleName: string,
         node: ts.ImportEqualsDeclaration | ts.ImportDeclaration
     ): boolean {
-        if (option.config.case === StringCase.any) {
-            if (makeCamelCase(expectedImportedName) === importedName || makePascalCase(expectedImportedName) === importedName) {
-                return true;
-            }
-        } else if (transformName(expectedImportedName).indexOf(importedName) > -1) {
+        if (transformName(expectedImportedName).indexOf(importedName) > -1) {
             return true;
         }
 

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -201,7 +201,7 @@ function walk(ctx: Lint.WalkContext<Option>) {
             if (makeCamelCase(expectedImportedName) === importedName || makePascalCase(expectedImportedName) === importedName) {
                 return true;
             }
-        } else if (transformName(expectedImportedName).includes(importedName)) {
+        } else if (transformName(expectedImportedName).indexOf(importedName) > -1) {
             return true;
         }
 

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -354,6 +354,30 @@ describe('importNameRule', (): void => {
                 const options = [true, {}, {}, { case: 'any-case' }];
                 TestHelper.assertViolationsWithOptions(ruleName, options, script, []);
             });
+
+            it('should fail', () => {
+                const script: string = `
+                    import gTag from 'x/y/z/graphql-tag';
+                `;
+                const options = [true, {}, {}, { case: 'any-case' }];
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, [
+                    {
+                        failure: "Misnamed import. Import should be named 'graphqlTag' or 'GraphqlTag' but found 'gTag'",
+                        fix: {
+                            innerStart: 28,
+                            innerLength: 4,
+                            innerText: 'graphqlTag'
+                        },
+                        name: Utils.absolutePath('file.ts'),
+                        ruleName: 'import-name',
+                        ruleSeverity: 'ERROR',
+                        startPosition: {
+                            character: 21,
+                            line: 2
+                        }
+                    }
+                ]);
+            });
         });
     });
 });

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -13,16 +13,6 @@ describe('importNameRule', (): void => {
         TestHelper.assertViolations(ruleName, script, []);
     });
 
-    it('should pass on matching names of ES6 import', (): void => {
-        const script: string = `
-            import App from 'App';
-            import App from 'x/y/z/App';
-            import graphqlTag from 'graphql-tag'
-        `;
-
-        TestHelper.assertViolations(ruleName, script, []);
-    });
-
     it('should pass on matching names of simple import', (): void => {
         const script: string = `
             import DependencyManager = DM.DependencyManager;
@@ -110,26 +100,6 @@ describe('importNameRule', (): void => {
                     innerStart: 20,
                     innerLength: 7,
                     innerText: 'DependencyManager'
-                }
-            }
-        ]);
-    });
-
-    it('should fail import with punctuation and underscore', (): void => {
-        const script: string = `
-            import UserSettings from "./user-settings.detail_view";
-        `;
-
-        TestHelper.assertViolations(ruleName, script, [
-            {
-                failure: "Misnamed import. Import should be named 'userSettingsDetailView' but found 'UserSettings'",
-                name: Utils.absolutePath('file.ts'),
-                ruleName: 'import-name',
-                startPosition: { character: 13, line: 2 },
-                fix: {
-                    innerStart: 20,
-                    innerLength: 12,
-                    innerText: 'userSettingsDetailView'
                 }
             }
         ]);
@@ -270,5 +240,106 @@ describe('importNameRule', (): void => {
         `;
 
         TestHelper.assertViolations(ruleName, script, []);
+    });
+    describe('caseSensetive', (): void => {
+        describe('camelCase', (): void => {
+            it('should pass on matching names of ES6 import', (): void => {
+                const script: string = `
+                    import App from 'App';
+                    import App from 'x/y/z/App';
+                    import graphqlTag from 'graphql-tag'
+                `;
+
+                const options = [
+                    true,
+                    {},
+                    {},
+                    {
+                        case: 'camelCase'
+                    }
+                ];
+
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, []);
+            });
+
+            it('should fail import with punctuation and underscore', (): void => {
+                const script: string = `
+                    import UserSettings from "./user-settings.detail_view";
+                `;
+
+                const options = [
+                    true,
+                    {},
+                    {},
+                    {
+                        case: 'camelCase'
+                    }
+                ];
+
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, [
+                    {
+                        failure: "Misnamed import. Import should be named 'userSettingsDetailView' but found 'UserSettings'",
+                        name: Utils.absolutePath('file.ts'),
+                        ruleName: 'import-name',
+                        startPosition: { character: 21, line: 2 },
+                        fix: {
+                            innerStart: 28,
+                            innerLength: 12,
+                            innerText: 'userSettingsDetailView'
+                        }
+                    }
+                ]);
+            });
+        });
+
+        describe('pascalCase', (): void => {
+            it('should pass on matching names of ES6 import', (): void => {
+                const script: string = `
+                    import App from 'App';
+                    import App from 'x/y/z/App';
+                    import GraphqlTag from 'graphql-tag'
+                `;
+
+                const options = [
+                    true,
+                    {},
+                    {},
+                    {
+                        case: 'PascalCase'
+                    }
+                ];
+
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, []);
+            });
+
+            it('should fail import with punctuation and underscore', (): void => {
+                const script: string = `
+                    import UserSettings from "./user-settings.detail_view";
+                `;
+
+                const options = [
+                    true,
+                    {},
+                    {},
+                    {
+                        case: 'PascalCase'
+                    }
+                ];
+
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, [
+                    {
+                        failure: "Misnamed import. Import should be named 'UserSettingsDetailView' but found 'UserSettings'",
+                        name: Utils.absolutePath('file.ts'),
+                        ruleName: 'import-name',
+                        startPosition: { character: 21, line: 2 },
+                        fix: {
+                            innerStart: 28,
+                            innerLength: 12,
+                            innerText: 'UserSettingsDetailView'
+                        }
+                    }
+                ]);
+            });
+        });
     });
 });

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -341,5 +341,19 @@ describe('importNameRule', (): void => {
                 ]);
             });
         });
+
+        describe('any-case', () => {
+            it('should pass on PascalCase and camelCase', () => {
+                const script: string = `
+                    import App from 'app';
+                    import app from 'app';
+                    import App from 'x/y/z/App';
+                    import GraphqlTag from 'x/y/z/graphql-tag';
+                    import graphqlTag from 'x/y/z/graphql-tag';
+                `;
+                const options = [true, {}, {}, { case: 'any-case' }];
+                TestHelper.assertViolationsWithOptions(ruleName, options, script, []);
+            });
+        });
     });
 });


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #830
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:
`import-name` update. It gives a possibility to set string case format (`camelCase` | `pascalCase`).


##### Examples:
###### Without update
```
// failure
import AbstractController from './controllers/abstract.controller';
```
```
// success
import abstractController from './controllers/abstract.controller';
```
###### With update
* camelCase
  * `"import-name": [true, {}, {}, { case: "camelCase" }],`
  * it's a default value
```
// failure
import AbstractController from './controllers/abstract.controller';
```
```
// success
import abstractController from './controllers/abstract.controller';
```
* PascalCase
  * `"import-name": [true, {}, {}, { case: "PascalCase" }],`
```
// failure
import abstractController from './controllers/abstract.controller';
```
```
// success
import AbstractController from './controllers/abstract.controller';
```
