### PR TITLE
update readme links to config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you extend from one of the following configurations, `rulesDirectory` will ha
 
 #### Recommended
 
-To start, you can enable our stable "recommended" defaults that come with tslint-microsoft-contrib ([recommended.json](./recommended.json)) by adding `"tslint-microsoft-contrib/recommended"` under `"extends"` in your `tslint.json`:
+To start, you can enable our stable "recommended" defaults that come with tslint-microsoft-contrib ([recommended.json](./configs/recommended.json)) by adding `"tslint-microsoft-contrib/recommended"` under `"extends"` in your `tslint.json`:
 
 ```json
 {
@@ -60,7 +60,7 @@ These rules will not be added to in minor or patch releases, but will be in majo
 
 #### Latest
 
-To run with the latest and greatest rules ([latest.json](./latest.json)), extend from `tslint-microsoft-contrib/latest`:
+To run with the latest and greatest rules ([latest.json](./configs/latest.json)), extend from `tslint-microsoft-contrib/latest`:
 
 ```json
 {
@@ -75,7 +75,7 @@ These rules will not be added to in patch releases, but will be in minor release
 
 The old "recommended" ruleset that ships by extending `tslint-microsoft-contrib` itself contains a list of rules that includes core TSLint rules.
 
-To start, you can enable our recommended defaults ([recommended.json](./recommended.json)) by adding just `"tslint-microsoft-contrib"` under `"extends"` in your `tslint.json`:
+To start, you can enable our recommended defaults ([recommended.json](./configs/recommended.json)) by adding just `"tslint-microsoft-contrib"` under `"extends"` in your `tslint.json`:
 
 ```json
 {


### PR DESCRIPTION
#### PR checklist

-   [x] Documentation update

#### Overview of change:

I think introduced in #809, the links from the readme 404 when reading on GitHub.

Happy to raise an issue instead of the PR - not totally clear from contributing guidelines/code-of-conduct what the expected route for small changes like this should be and don't want to overload maintainers with something small!