### PR TITLE
Update TSLint for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
     "recommendations": [
         // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
         "EditorConfig.EditorConfig",
-        "eg2.tslint",
+        "ms-vscode.vscode-typescript-tslint-plugin",
         "esbenp.prettier-vscode"
     ]
 }


### PR DESCRIPTION
eg2.tslint has been deprecated in favor of the
ms-vscode.vscode-typescript-tslint-plugin

Fixes #821.

#### PR checklist

- [v] vs code plugin update

#### Overview of change:

`eg2.tslint` has been deprecated in favor of the `ms-vscode.vscode-typescript-tslint-plugin`.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->
