### PR TITLE
Expand prefer-array-literal rule

### DIFF
--- a/src/preferArrayLiteralRule.ts
+++ b/src/preferArrayLiteralRule.ts
@@ -27,6 +27,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static GENERICS_FAILURE_STRING: string = 'Replace generic-typed Array with array literal: ';
     public static CONSTRUCTOR_FAILURE_STRING: string = 'Replace Array constructor with an array literal: ';
+    public static FUNCTION_FAILURE_STRING: string = 'Replace Array function with an array literal: ';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, this.parseOptions(this.getOptions()));
@@ -73,6 +74,14 @@ function walk(ctx: Lint.WalkContext<Options>) {
             const functionName = AstUtils.getFunctionName(node);
             if (functionName === 'Array') {
                 const failureString = Rule.CONSTRUCTOR_FAILURE_STRING + node.getText();
+                ctx.addFailureAt(node.getStart(), node.getWidth(), failureString);
+            }
+        }
+
+        if (tsutils.isCallExpression(node)) {
+            const expr = node.expression;
+            if (expr.getText() === 'Array') {
+                const failureString = Rule.FUNCTION_FAILURE_STRING + node.getText();
                 ctx.addFailureAt(node.getStart(), node.getWidth(), failureString);
             }
         }

--- a/src/tests/ReactA11yTitlesRuleTests.ts
+++ b/src/tests/ReactA11yTitlesRuleTests.ts
@@ -49,7 +49,7 @@ describe('reactA11yTitlesRule', (): void => {
     });
 
     it('should fail on longer than 60 charactes title', (): void => {
-        const title: string = Array(61).join('a');
+        const title: string = 'a'.repeat(60);
         const script: string = `
             import React = require('react');
 
@@ -70,7 +70,7 @@ describe('reactA11yTitlesRule', (): void => {
     });
 
     it('should pass on shorter than 60 characters title', (): void => {
-        const title: string = Array(5).join('a');
+        const title: string = 'a'.repeat(5);
         const script: string = `
             import React = require('react');
 

--- a/src/tests/preferArrayLiteralRuleTests.ts
+++ b/src/tests/preferArrayLiteralRuleTests.ts
@@ -78,4 +78,16 @@ describe('preferArrayLiteralRule', (): void => {
             }
         ]);
     });
+
+    it('should ban Array function', (): void => {
+        const inputScript: string = 'Array(2)';
+        TestHelper.assertViolations(ruleName, inputScript, [
+            {
+                failure: 'Replace Array function with an array literal: Array(2)',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'prefer-array-literal',
+                startPosition: { character: 1, line: 1 }
+            }
+        ]);
+    });
 });


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #839 
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests


#### Overview of change:
Expands the `prefer-array-literal` rule to cover Array functions
#### Is there anything you'd like reviewers to focus on?
After implementing this change, `react-a11y-titles` test was was flagged by the rule update and i made some changes to it as part of this PR. I am unsure if it's appropriate to include those changes here or it should be part of another issue to address the breaking change.  @JoshuaKGoldberg, @IllusionMH  thoughts?
<!-- optional -->
