### PR TITLE
Add kebab and snake case support to export-name rule

### DIFF
--- a/src/exportNameRule.ts
+++ b/src/exportNameRule.ts
@@ -156,13 +156,20 @@ function walk(ctx: Lint.WalkContext<Options>) {
         const flags = ignoreCase ? 'i' : '';
         const regex: RegExp = new RegExp(`^${exportedName}\\..+`, flags); // filename must be exported name plus any extension
         const fileName = Utils.fileBasename(ctx.sourceFile.fileName);
+        const fileNameAsCamelCase = convertSnakeOrKebabCaseName(fileName);
 
-        if (!regex.test(fileName)) {
+        if (!regex.test(fileNameAsCamelCase)) {
             if (!isSuppressed(exportedName)) {
                 const failureString: string = Rule.FAILURE_STRING + fileName + ' and ' + exportedName;
                 ctx.addFailureAt(tsNode.getStart(), tsNode.getWidth(), failureString);
             }
         }
+    }
+
+    function convertSnakeOrKebabCaseName(rawName: string): string {
+        const snakeOrKebabRegex = /((\-|\_)\w)/g;
+
+        return rawName.replace(snakeOrKebabRegex, (match: string): string => match[1].toUpperCase());
     }
 
     function isSuppressed(exportedName: string): boolean {

--- a/src/tests/ExportNameRuleTests.ts
+++ b/src/tests/ExportNameRuleTests.ts
@@ -234,6 +234,16 @@ describe('exportNameRule', (): void => {
 
             TestHelper.assertViolations(ruleName, script, []);
         });
+
+        it('when file name is in kebab case', (): void => {
+            const inputFile: string = 'test-data/ExportName/export-name-rule-passing-test-input-3.tsx';
+            TestHelper.assertViolations(ruleName, inputFile, []);
+        });
+
+        it('when file name is in snake case', (): void => {
+            const inputFile: string = 'test-data/ExportName/export_name_rule_passing_test_input_4.tsx';
+            TestHelper.assertViolations(ruleName, inputFile, []);
+        });
     });
 
     describe('should fail', (): void => {

--- a/test-data/ExportName/export-name-rule-passing-test-input-3.tsx
+++ b/test-data/ExportName/export-name-rule-passing-test-input-3.tsx
@@ -1,0 +1,2 @@
+class ExportNameRulePassingTestInput3 {}
+export = ExportNameRulePassingTestInput3; // matches filename

--- a/test-data/ExportName/export_name_rule_passing_test_input_4.tsx
+++ b/test-data/ExportName/export_name_rule_passing_test_input_4.tsx
@@ -1,0 +1,2 @@
+class ExportNameRulePassingTestInput4 {}
+export = ExportNameRulePassingTestInput4; // matches filename


### PR DESCRIPTION
#### PR checklist

-   [X] Addresses an existing issue: fixes #814
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:

Right now the export-name rule only works for files that are named in pascal- or camel-case. This PR adds support for files named in kebab- or snake-case.
