### PR TITLE
Fixed decorated methods declared after usage (#813)

### DIFF
--- a/src/tests/ReactThisBindingIssueRuleTests.ts
+++ b/src/tests/ReactThisBindingIssueRuleTests.ts
@@ -12,6 +12,11 @@ describe('reactThisBindingIssueRule', (): void => {
         TestHelper.assertNoViolationWithOptions(ruleName, [true, { 'bind-decorators': ['autobind'] }], fileWithDecorator);
     });
 
+    it('should pass even if a decorated method declared after usage', (): void => {
+        const file: string = 'test-data/ReactThisBinding/ReactThisBindingIssueWithDecoratorDeclaredAfterUsage-passing.tsx';
+        TestHelper.assertNoViolationWithOptions(ruleName, [true, { 'bind-decorators': ['autobind'] }], file);
+    });
+
     it('should fail if decorator is not whitelisted in config', () => {
         const fileWithDecorator: string = 'test-data/ReactThisBinding/ReactThisBindingIssueWithDecorator-passing.tsx';
         const expectedMsg = `A class method is passed as a JSX attribute without having the 'this' reference bound: `;

--- a/test-data/ReactThisBinding/ReactThisBindingIssueWithDecoratorDeclaredAfterUsage-passing.tsx
+++ b/test-data/ReactThisBinding/ReactThisBindingIssueWithDecoratorDeclaredAfterUsage-passing.tsx
@@ -1,0 +1,12 @@
+import React = require('react');
+
+declare const autobind: MethodDecorator;
+
+export class MyComponent extends React.Component {
+    public render() {
+        return <div onClick={this.listener1} />;
+    }
+
+    @autobind
+    private listener1(): void {}
+}


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #813
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:

This MR fixes a bug with `react-this-binding-issue` rule when the decorated method was declared after usage. 

