### PR TITLE
react-a11y-no-onchange: Allow onChange when onBlur is present (#836)

### DIFF
--- a/src/reactA11yNoOnchangeRule.ts
+++ b/src/reactA11yNoOnchangeRule.ts
@@ -59,7 +59,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
         }
 
         const attributes = getJsxAttributesFromJsxElement(node);
-        if (attributes.hasOwnProperty('onchange')) {
+        if (attributes.hasOwnProperty('onchange') && !attributes.hasOwnProperty('onblur')) {
             const errorMessage = `onChange event handler should not be used with the <${tagName}>. Please use onBlur instead.`;
             ctx.addFailureAt(node.getStart(), node.getWidth(), errorMessage);
         }

--- a/src/tests/ReactA11yNoOnchangeRuleTests.ts
+++ b/src/tests/ReactA11yNoOnchangeRuleTests.ts
@@ -35,6 +35,15 @@ describe('reactA11yNoOnchangeRule', (): void => {
         ]);
     });
 
+    it('should not fail if select element attributes contains onBlur event even if it also contains onChange event', (): void => {
+        const script: string = `
+            import React = require('react');
+            const selectElementWithOnChange = <select  onChange={} onBlur={} />\`;
+        `;
+
+        TestHelper.assertNoViolation(ruleName, script);
+    });
+
     it('should fail if additional tag name specified in options contains onChange event', () => {
         const script: string = `
             import React = require('react');


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #836
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:

react-a11y-no-onchange: Allow onChange when onBlur is present
