### PR TITLE
ignore input type="file" from react-a11y-input-elements 

### DIFF
--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -51,12 +51,14 @@ function isTypeMatchedTo(
     attributes: { [propName: string]: ts.JsxAttribute },
     condition: (attributeText: string) => boolean
 ): boolean {
+    if (attributes.type === undefined) {
+        return false;
+    }
     for (const attribute of node.attributes.properties) {
         if (tsutils.isJsxAttribute(attribute)) {
-            const isInputAttributeType = attributes.type;
             if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
                 const attributeText = attribute.initializer.text;
-                if (isInputAttributeType !== undefined && condition(attributeText)) {
+                if (condition(attributeText)) {
                     return true;
                 }
             }

--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -46,13 +46,17 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-function isExcludedInputType(node: ts.JsxSelfClosingElement, attributes: { [propName: string]: ts.JsxAttribute }): boolean {
+function isTypeMatchedTo(
+    node: ts.JsxSelfClosingElement,
+    attributes: { [propName: string]: ts.JsxAttribute },
+    condition: (attributeText: string) => boolean
+): boolean {
     for (const attribute of node.attributes.properties) {
         if (tsutils.isJsxAttribute(attribute)) {
             const isInputAttributeType = attributes.type;
             if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
                 const attributeText = attribute.initializer.text;
-                if (isInputAttributeType !== undefined && EXCLUDED_INPUT_TYPES.indexOf(attributeText) !== -1) {
+                if (isInputAttributeType !== undefined && condition(attributeText)) {
                     return true;
                 }
             }
@@ -61,19 +65,12 @@ function isExcludedInputType(node: ts.JsxSelfClosingElement, attributes: { [prop
     return false;
 }
 
+function isExcludedInputType(node: ts.JsxSelfClosingElement, attributes: { [propName: string]: ts.JsxAttribute }): boolean {
+    return isTypeMatchedTo(node, attributes, attributeText => EXCLUDED_INPUT_TYPES.indexOf(attributeText) !== -1);
+}
+
 function isInputTypeFile(node: ts.JsxSelfClosingElement, attributes: { [propName: string]: ts.JsxAttribute }): boolean {
-    for (const attribute of node.attributes.properties) {
-        if (tsutils.isJsxAttribute(attribute)) {
-            const isInputAttributeType = attributes.type;
-            if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
-                const attributeText = attribute.initializer.text;
-                if (isInputAttributeType !== undefined && attributeText === 'file') {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
+    return isTypeMatchedTo(node, attributes, attributeText => attributeText === 'file');
 }
 
 function walk(ctx: Lint.WalkContext<void>) {

--- a/src/reactA11yInputElementsRule.ts
+++ b/src/reactA11yInputElementsRule.ts
@@ -8,7 +8,7 @@ import { ExtendedMetadata } from './utils/ExtendedMetadata';
 export const MISSING_PLACEHOLDER_INPUT_FAILURE_STRING: string = 'Input elements must include default, place-holding characters if empty';
 export const MISSING_PLACEHOLDER_TEXTAREA_FAILURE_STRING: string =
     'Textarea elements must include default, place-holding characters if empty';
-const EXCLUDED_INPUT_TYPES = ['checkbox', 'radio', 'file'];
+const EXCLUDED_INPUT_TYPES = ['checkbox', 'radio'];
 
 /**
  * Implementation of the react-a11y-input-elements rule.
@@ -61,6 +61,21 @@ function isExcludedInputType(node: ts.JsxSelfClosingElement, attributes: { [prop
     return false;
 }
 
+function isInputTypeFile(node: ts.JsxSelfClosingElement, attributes: { [propName: string]: ts.JsxAttribute }): boolean {
+    for (const attribute of node.attributes.properties) {
+        if (tsutils.isJsxAttribute(attribute)) {
+            const isInputAttributeType = attributes.type;
+            if (attribute.initializer !== undefined && tsutils.isStringLiteral(attribute.initializer)) {
+                const attributeText = attribute.initializer.text;
+                if (isInputAttributeType !== undefined && attributeText === 'file') {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 function walk(ctx: Lint.WalkContext<void>) {
     function cb(node: ts.Node): void {
         if (tsutils.isJsxSelfClosingElement(node)) {
@@ -71,6 +86,11 @@ function walk(ctx: Lint.WalkContext<void>) {
                 const isExcludedInput = isExcludedInputType(node, attributes);
                 const isExcludedInputTypeValueEmpty = isEmpty(attributes.value) && isExcludedInput;
                 const isPlaceholderEmpty = isEmpty(attributes.placeholder) && !isExcludedInput;
+
+                if (isInputTypeFile(node, attributes)) {
+                    return;
+                }
+
                 if ((isEmpty(attributes.value) && isPlaceholderEmpty) || isExcludedInputTypeValueEmpty) {
                     ctx.addFailureAt(node.getStart(), node.getWidth(), MISSING_PLACEHOLDER_INPUT_FAILURE_STRING);
                 }

--- a/src/tests/ReactA11yInputElementsRuleTests.ts
+++ b/src/tests/ReactA11yInputElementsRuleTests.ts
@@ -20,6 +20,15 @@ describe('reactA11yInputElementsRule', (): void => {
         TestHelper.assertViolations(ruleName, script, []);
     });
 
+    it('should pass on input elements of file without value and placeholder', (): void => {
+        const script: string = `
+            import React = require('react');
+            const a = <input type="file" />;
+        `;
+
+        TestHelper.assertViolations(ruleName, script, []);
+    });
+
     it('should pass on input elements without placeholder of type radio, checkbox, file', (): void => {
         const script: string = `
             import React = require('react');
@@ -31,12 +40,11 @@ describe('reactA11yInputElementsRule', (): void => {
         TestHelper.assertViolations(ruleName, script, []);
     });
 
-    it('should fail on input elements without value of type radio, checkbox, file', (): void => {
+    it('should fail on input elements without value of type radio, checkbox', (): void => {
         const script: string = `
             import React = require('react');
             const a = <input type="radio" />;
             const b = <input type="checkbox" />;
-            const c = <input type="file" />;
         `;
 
         TestHelper.assertViolations(ruleName, script, [
@@ -51,12 +59,6 @@ describe('reactA11yInputElementsRule', (): void => {
                 name: Utils.absolutePath('file.tsx'),
                 ruleName: 'react-a11y-input-elements',
                 startPosition: { character: 23, line: 4 }
-            },
-            {
-                failure: MISSING_PLACEHOLDER_INPUT_FAILURE_STRING,
-                name: Utils.absolutePath('file.tsx'),
-                ruleName: 'react-a11y-input-elements',
-                startPosition: { character: 23, line: 5 }
             }
         ]);
     });


### PR DESCRIPTION
#### PR checklist

-   [x] Addresses an existing issue: fixes #841
-   [x] bugfix
    -   [x] Includes tests
-   [ ] Documentation update

#### Overview of change:
Ignore any `<input type="file">` from react-a11y-input-elements because both `placeholder` and `value` attributes are ignored by browsers or screen readers. 

#### Is there anything you'd like reviewers to focus on?
Should I update any document ?

<!-- optional -->
