### PR TITLE
Handle TS exceptions in no-string-based-x rules

### DIFF
--- a/src/utils/createNoStringParameterToFunctionWalker.ts
+++ b/src/utils/createNoStringParameterToFunctionWalker.ts
@@ -115,6 +115,9 @@ export function createNoStringParameterToFunctionWalker(
         if (expression.expression.kind === ts.SyntaxKind.PropertyAccessExpression && typeChecker) {
             const propExp: ts.PropertyAccessExpression = <ts.PropertyAccessExpression>expression.expression;
             try {
+                // TS might throw exceptions in non-standard conditions (like .vue files)
+                // Use try...catch blocks to fallback to the same behavior as when checker is not available
+                // See https://github.com/microsoft/tslint-microsoft-contrib/issues/859
                 const targetType: ts.Type = typeChecker.getTypeAtLocation(propExp.expression);
                 return typeChecker.typeToString(targetType);
             } catch {
@@ -147,13 +150,16 @@ export function createNoStringParameterToFunctionWalker(
 
         if (expression.kind === ts.SyntaxKind.Identifier && typeChecker) {
             try {
+                // TS might throw exceptions in non-standard conditions (like .vue files)
+                // Use try...catch blocks to fallback to the same behavior as when checker is not available
+                // See https://github.com/microsoft/tslint-microsoft-contrib/issues/859
                 const tsSymbol = typeChecker.getSymbolAtLocation(expression);
                 if (tsSymbol && tsSymbol.flags === ts.SymbolFlags.Function) {
                     return true; // variables with type function are OK to pass
                 }
                 return false;
             } catch {
-                // no return statement to use same behavior as when typeChecker is not available
+                // No return statement to use same behavior as when typeChecker is not available
             }
         }
 
@@ -185,6 +191,9 @@ export function createNoStringParameterToFunctionWalker(
             return true;
         }
         try {
+            // TS might throw exceptions in non-standard conditions (like .vue files)
+            // Use try...catch blocks to fallback to the same behavior as when checker is not available
+            // See https://github.com/microsoft/tslint-microsoft-contrib/issues/859
             return isFunctionType(typeChecker.getTypeAtLocation(expression), typeChecker);
         } catch {
             // same return value as when typeChecker is not available

--- a/src/utils/createNoStringParameterToFunctionWalker.ts
+++ b/src/utils/createNoStringParameterToFunctionWalker.ts
@@ -85,10 +85,10 @@ export function createNoStringParameterToFunctionWalker(
     function validateExpression(node: ts.CallExpression, ctx: Lint.WalkContext<void>): void {
         const functionName = AstUtils.getFunctionName(node);
         const functionTarget = AstUtils.getFunctionTarget(node);
-        const functionTargetType = getFunctionTargetType(node);
         const firstArg: ts.Expression = node.arguments[0];
         if (functionName === targetFunctionName && firstArg !== undefined) {
             if (functionTarget) {
+                const functionTargetType = getFunctionTargetType(node);
                 if (functionTargetType) {
                     if (!functionTargetType.match(/^(any|Window|Worker)$/)) {
                         return;


### PR DESCRIPTION
#### PR checklist

-   [X] Addresses an existing issue: fixes #859 (mitigates)
-   [X] ~New feature,~ bugfix, ~or enhancement~
    -   [ ] Includes tests
-   [ ] Documentation update

#### Overview of change:
This PR does two things:
1. Defers type check to the moment when potential violation found.
1. Wraps all calls to `typeChecker.getTypeAtLocation` in `try..catch` and restores same behavir when type checker is not available.

This PR doesn't fix root cause of #859 but at least rules won't throw an exception.

#### Is there anything you'd like reviewers to focus on?
No unit tests for specific case because issue is noticeable in only in Vue. Should I add tests to handle this exceptional case?

<!-- optional -->
