### PR TITLE
fix: In function-name, actually run static regex for static private when option indicates that it should

### DIFF
--- a/src/functionNameRule.ts
+++ b/src/functionNameRule.ts
@@ -125,71 +125,108 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<Options>) {
     const { validateStatics, methodRegex, privateMethodRegex, protectedMethodRegex, staticMethodRegex, functionRegex } = ctx.options;
 
+    function validateAnyPattern(name: ts.PropertyName | ts.Identifier, patterns: RegExp[], messagePrefix: string): void {
+        const nameText: string = name.getText();
+        if (!patterns.some(pattern => pattern.test(nameText))) {
+            ctx.addFailureAt(name.getStart(), name.getWidth(), `${messagePrefix}: ${nameText}`);
+        }
+    }
+
+    function handleStaticMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(method.name, [staticMethodRegex], `Static method name does not match ${staticMethodRegex}`);
+    }
+
+    function handlePrivateMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(method.name, [privateMethodRegex], `Private method name does not match ${privateMethodRegex}`);
+    }
+
+    function handlePrivateOrStaticMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(
+            method.name,
+            [privateMethodRegex, staticMethodRegex],
+            `Private static method name does not match ${privateMethodRegex} or ${staticMethodRegex}`
+        );
+    }
+
+    function handleProtectedMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(method.name, [protectedMethodRegex], `Protected method name does not match ${protectedMethodRegex}`);
+    }
+
+    function handleProtectedOrStaticMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(
+            method.name,
+            [protectedMethodRegex, staticMethodRegex],
+            `Protected static method name does not match ${protectedMethodRegex} or ${staticMethodRegex}`
+        );
+    }
+
+    function handleOtherMethod(method: ts.MethodDeclaration) {
+        validateAnyPattern(method.name, [methodRegex], `Method name does not match ${methodRegex}`);
+    }
+
+    // routes to different handler logic depending on validate statics configuration
+    const methodRouter: { [key: string]: (method: ts.MethodDeclaration) => void } = {
+        [VALIDATE_PRIVATE_STATICS_AS_PRIVATE]: (method: ts.MethodDeclaration) => {
+            // private/protected first priority
+            if (AstUtils.isPrivate(method)) {
+                handlePrivateMethod(method);
+            } else if (AstUtils.isProtected(method)) {
+                handleProtectedMethod(method);
+            } else if (AstUtils.isStatic(method)) {
+                handleStaticMethod(method);
+            } else {
+                handleOtherMethod(method);
+            }
+        },
+        [VALIDATE_PRIVATE_STATICS_AS_STATIC]: (method: ts.MethodDeclaration) => {
+            // static first priority
+            if (AstUtils.isStatic(method)) {
+                handleStaticMethod(method);
+            } else if (AstUtils.isPrivate(method)) {
+                handlePrivateMethod(method);
+            } else if (AstUtils.isProtected(method)) {
+                handleProtectedMethod(method);
+            } else {
+                handleOtherMethod(method);
+            }
+        },
+        [VALIDATE_PRIVATE_STATICS_AS_EITHER]: (method: ts.MethodDeclaration) => {
+            // either private/protected or static
+            if (AstUtils.isStatic(method)) {
+                if (AstUtils.isPrivate(method)) {
+                    // private AND static methods pass if it matches either private regex OR static regex
+                    handlePrivateOrStaticMethod(method);
+                } else if (AstUtils.isProtected(method)) {
+                    // protected AND static methods pass if it matches either protected regex OR static regex
+                    handleProtectedOrStaticMethod(method);
+                } else {
+                    handleStaticMethod(method);
+                }
+            } else if (AstUtils.isPrivate(method)) {
+                handlePrivateMethod(method);
+            } else if (AstUtils.isProtected(method)) {
+                handleProtectedMethod(method);
+            } else {
+                handleOtherMethod(method);
+            }
+        }
+    };
+
     function cb(node: ts.Node): void {
         if (tsutils.isMethodDeclaration(node)) {
-            const name: string = node.name.getText();
-
-            const isComputed = AstUtils.hasComputedName(node);
-            const isPrivate = AstUtils.isPrivate(node);
-            const isProtected = AstUtils.isProtected(node);
-            const isStatic = AstUtils.isStatic(node);
-
-            const staticOnly = isStatic && validateStatics === VALIDATE_PRIVATE_STATICS_AS_STATIC;
-            const privateOnly = (isPrivate || isProtected) && validateStatics === VALIDATE_PRIVATE_STATICS_AS_PRIVATE;
-
-            if (isComputed) {
+            if (AstUtils.hasComputedName(node)) {
                 // allow computed names
-            } else if (isPrivate && isStatic && validateStatics === VALIDATE_PRIVATE_STATICS_AS_EITHER) {
-                if (!privateMethodRegex.test(name) && !staticMethodRegex.test(name)) {
-                    ctx.addFailureAt(
-                        node.name.getStart(),
-                        node.name.getWidth(),
-                        `Private static method name does not match ${privateMethodRegex} or ${staticMethodRegex}: ${name}`
-                    );
-                }
-            } else if (isProtected && isStatic && validateStatics === VALIDATE_PRIVATE_STATICS_AS_EITHER) {
-                if (!protectedMethodRegex.test(name) && !staticMethodRegex.test(name)) {
-                    ctx.addFailureAt(
-                        node.name.getStart(),
-                        node.name.getWidth(),
-                        `Protected static method name does not match ${protectedMethodRegex} or ${staticMethodRegex}: ${name}`
-                    );
-                }
-            } else if (isPrivate && !staticOnly) {
-                if (!privateMethodRegex.test(name)) {
-                    ctx.addFailureAt(
-                        node.name.getStart(),
-                        node.name.getWidth(),
-                        `Private method name does not match ${privateMethodRegex}: ${name}`
-                    );
-                }
-            } else if (isProtected && !staticOnly) {
-                if (!protectedMethodRegex.test(name)) {
-                    ctx.addFailureAt(
-                        node.name.getStart(),
-                        node.name.getWidth(),
-                        `Protected method name does not match ${protectedMethodRegex}: ${name}`
-                    );
-                }
-            } else if (isStatic && !privateOnly) {
-                if (!staticMethodRegex.test(name)) {
-                    ctx.addFailureAt(
-                        node.name.getStart(),
-                        node.name.getWidth(),
-                        `Static method name does not match ${staticMethodRegex}: ${name}`
-                    );
-                }
-            } else if (!methodRegex.test(name)) {
-                ctx.addFailureAt(node.name.getStart(), node.name.getWidth(), `Method name does not match ${methodRegex}: ${name}`);
+            } else {
+                // find handler based on validate statics configuration
+                // fallback on private statics as private
+                const handler = methodRouter[validateStatics] || methodRouter[VALIDATE_PRIVATE_STATICS_AS_PRIVATE];
+                handler(node);
             }
         }
 
         if (tsutils.isFunctionDeclaration(node)) {
             if (node.name !== undefined) {
-                const name: string = node.name.text;
-                if (!functionRegex.test(name)) {
-                    ctx.addFailureAt(node.name.getStart(), node.name.getWidth(), `Function name does not match ${functionRegex}: ${name}`);
-                }
+                validateAnyPattern(node.name, [functionRegex], `Function name does not match ${functionRegex}`);
             }
         }
 

--- a/src/tests/FunctionNameRuleTests.ts
+++ b/src/tests/FunctionNameRuleTests.ts
@@ -152,6 +152,59 @@ describe('functionNameRule', (): void => {
         TestHelper.assertNoViolationWithOptions(ruleName, ['true', 'validate-private-statics-as-either'], script);
     });
 
+    it('should fail on incorrectly private or protected static methods as either with option', (): void => {
+        const script: string = `
+        class MyClass {
+            private static Bar() {}
+            protected static Bar1() {}
+        }`;
+
+        TestHelper.assertViolationsWithOptions(ruleName, [true, 'validate-private-statics-as-either'], script, [
+            {
+                failure: 'Private static method name does not match /^[a-z][\\w\\d]+$/ or /^[A-Z_\\d]+$/: Bar',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'function-name',
+                startPosition: { character: 28, line: 3 }
+            },
+            {
+                failure: 'Protected static method name does not match /^[a-z][\\w\\d]+$/ or /^[A-Z_\\d]+$/: Bar1',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'function-name',
+                startPosition: { character: 30, line: 4 }
+            }
+        ]);
+    });
+
+    it('should fail on incorrect static with validate-private-statics-as-static option', (): void => {
+        const script: string = `
+        class MyClass {
+            private static somePrivateStaticMethod() {}
+            protected static someProtectedStaticMethod() {}
+            public static somePublicStaticMethod() {}
+        }`;
+
+        TestHelper.assertViolationsWithOptions(ruleName, [true, 'validate-private-statics-as-static'], script, [
+            {
+                failure: 'Static method name does not match /^[A-Z_\\d]+$/: somePrivateStaticMethod',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'function-name',
+                startPosition: { character: 28, line: 3 }
+            },
+            {
+                failure: 'Static method name does not match /^[A-Z_\\d]+$/: someProtectedStaticMethod',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'function-name',
+                startPosition: { character: 30, line: 4 }
+            },
+            {
+                failure: 'Static method name does not match /^[A-Z_\\d]+$/: somePublicStaticMethod',
+                name: Utils.absolutePath('file.ts'),
+                ruleName: 'function-name',
+                startPosition: { character: 27, line: 5 }
+            }
+        ]);
+    });
+
     it('should fail on incorrect public methods', (): void => {
         const script: string = `
             class MyClass {


### PR DESCRIPTION
Fixing function-name rule functionality added by PR #501.  These options should be reworked in the future, but the intent of this change is that the existing intended functionality is met.

#### PR checklist

-   [x] Addresses an existing issue: fixes #661
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [x] Documentation update

#### Overview of change:

The function-name rule supports options for handling private/protected static methods.  The default option is "validate-private-statics-as-private", which means that private/protected static methods will only validate against the private-method regex.

When changing to the either the "validate-private-statics-as-either" or "validate-private-statics-as-static" option, it would not perform and validation on private/protected static methods.

After the change, "validate-private-statics-as-static" will only validate against the static-method regex, and "validate-private-statics-as-either" will validate against both, but only add a failure if both fail to match.