### PR TITLE
fix: `import-name` options bugs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,16 @@ We recommend you specify exact versions of lint libraries, including `tslint-mic
       </td>
       <td>
         The name of the imported module must match the name of the thing being imported. For special characters (<code>-</code>, <code>.</code>, <code>_</code>) remove them and make the following character uppercase.
-        For example, it is valid to name imported modules the same as the module name: <code>import Service = require('x/y/z/Service')</code> and <code>import Service from 'x/y/z/Service'</code>.
+        For example, it is valid to name imported modules the same as the module name: <code>import Service = require('./x/y/z/Service')</code> and <code>import Service from './x/y/z/Service'</code>.
         But it is invalid to change the name being imported, such as: <code>import MyCoolService = require('x/y/z/Service')</code> and <code>import MyCoolService from 'x/y/z/Service'</code>.
         When containing special characters such as <code>import $$ from 'my-awesome_library';</code> the corresponding configuration would look like <code>'import-name': [true, { 'myAwesomeLibrary': '$$' }]</code>.
         Since version 2.0.9 it is possible to configure this rule with a list of exceptions.
-        For example, to allow <code>underscore</code> to be imported as <code>_</code>, add this configuration: <code>'import-name': [ true, { 'underscore': '_' }]</code>
+        The default is to ignore this rule for external modules <code>ignoreExternalModule: true</code> and to use camelCase <code>case: 'camelCase'</code>.
+        To not ignore this rule for external modules, add this configuration: <code>'import-name': [true, null, null, { ignoreExternalModule: false }]</code>.
+        To allow <code>underscore</code> to be imported as <code>_</code>, add this configuration: <code>'import-name': [true, { 'underscore': '_' }, null, { ignoreExternalModule: false }]</code>.
+        To ignore this rule for <code>react</code> and <code>express</code>, add this configuration: <code>'import-name': [true, null, ['react', 'express'], { ignoreExternalModule: false }]</code>.
+        To use PascalCase: <code>'import-name': [true, null, null, { case: 'PascalCase' }]</code>.
+        To use camelCase or PascalCase: <code>'import-name': [true, null, null, { case: 'any-case' }]</code>.
       </td>
       <td>2.0.5</td>
     </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,8 +1299,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1321,14 +1320,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1343,20 +1340,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1473,8 +1467,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1486,7 +1479,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1501,7 +1493,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1509,14 +1500,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1535,7 +1524,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1616,8 +1604,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1629,7 +1616,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1715,8 +1701,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1752,7 +1737,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1772,7 +1756,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1816,14 +1799,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -45,15 +45,15 @@ export class Rule extends Lint.Rules.AbstractRule {
 
         if (options.ruleArguments instanceof Array) {
             options.ruleArguments.forEach((opt: unknown, index: number) => {
-                if (index === 1 && isObject(opt)) {
+                if (index === 0 && isObject(opt)) {
                     result.replacements = this.extractReplacements(opt);
                 }
 
-                if (index === 2 && Array.isArray(opt)) {
+                if (index === 1 && Array.isArray(opt)) {
                     result.ignoredList = this.extractIgnoredList(opt);
                 }
 
-                if (index === 3 && isObject(opt)) {
+                if (index === 2 && isObject(opt)) {
                     result.config = this.extractConfig(opt);
                 }
             });

--- a/src/importNameRule.ts
+++ b/src/importNameRule.ts
@@ -233,12 +233,14 @@ function walk(ctx: Lint.WalkContext<Option>) {
     }
 
     function makeCamelCase(input: string): string {
-        return input.replace(
+        let result = `${input.charAt(0)}${input.slice(1)}`;
+        result = result.replace(
             /[-|\.|_](.)/g, // tslint:disable-next-line:variable-name
             (_match: string, group1: string): string => {
                 return group1.toUpperCase();
             }
         );
+        return result;
     }
 
     function makePascalCase(input: string): string {

--- a/src/tests/ImportNameRuleTests.ts
+++ b/src/tests/ImportNameRuleTests.ts
@@ -114,7 +114,6 @@ describe('importNameRule', (): void => {
         `;
 
         const options = [
-            true,
             {
                 backbone: 'Backbone',
                 react: 'React',
@@ -132,7 +131,6 @@ describe('importNameRule', (): void => {
         import pqr from 'my-module'
         `;
         const options = [
-            true,
             {
                 'fs/package-name': 'pkg',
                 'abc-tag': 'abc',
@@ -151,7 +149,6 @@ describe('importNameRule', (): void => {
         import Up from 'up-module'
         `;
         const options = [
-            true,
             {
                 'fs/package-name': 'pkg',
                 'abc-tag': 'abc',
@@ -171,7 +168,6 @@ describe('importNameRule', (): void => {
         import Up from 'up-module'
         `;
         const options = [
-            true,
             {
                 'fs/package-name': 'pkg',
                 'abc-tag': 'abc',
@@ -251,7 +247,6 @@ describe('importNameRule', (): void => {
                 `;
 
                 const options = [
-                    true,
                     {},
                     {},
                     {
@@ -268,7 +263,6 @@ describe('importNameRule', (): void => {
                 `;
 
                 const options = [
-                    true,
                     {},
                     {},
                     {
@@ -301,7 +295,6 @@ describe('importNameRule', (): void => {
                 `;
 
                 const options = [
-                    true,
                     {},
                     {},
                     {
@@ -318,7 +311,6 @@ describe('importNameRule', (): void => {
                 `;
 
                 const options = [
-                    true,
                     {},
                     {},
                     {
@@ -351,7 +343,7 @@ describe('importNameRule', (): void => {
                     import GraphqlTag from 'x/y/z/graphql-tag';
                     import graphqlTag from 'x/y/z/graphql-tag';
                 `;
-                const options = [true, {}, {}, { case: 'any-case' }];
+                const options = [{}, {}, { case: 'any-case' }];
                 TestHelper.assertViolationsWithOptions(ruleName, options, script, []);
             });
 
@@ -359,7 +351,7 @@ describe('importNameRule', (): void => {
                 const script: string = `
                     import gTag from 'x/y/z/graphql-tag';
                 `;
-                const options = [true, {}, {}, { case: 'any-case' }];
+                const options = [{}, {}, { case: 'any-case' }];
                 TestHelper.assertViolationsWithOptions(ruleName, options, script, [
                     {
                         failure: "Misnamed import. Import should be named 'graphqlTag' or 'GraphqlTag' but found 'gTag'",


### PR DESCRIPTION
#### PR checklist

-   [ ] Addresses an existing issue: fixes #0000
-   [x] New feature, bugfix, or enhancement
    -   [x] Includes tests
-   [x] Documentation update

#### Overview of change:
`import-name` rule has an off-by-one bug where it selects options starting from the wrong index. I updated the tests to match this.

I also noticed that for `camelCase`, it allowed the first letter to be upper-case. `any-case` is either `PascalCase` or `camelCase`, but since `camelCase` allowed the first letter to be upper case, `any-case` and `camelCase` are currently the same. I enforced the first letter to be lowercase.

I also updated the documentation. It's a bit lacking right now. It doesn't explain all of the allowed options.

#### Is there anything you'd like reviewers to focus on?

Not completely related but, I found this bug from #881. In #881, I had other problems.
