### PR TITLE
Add missing `dir` to the `no-console`

### DIFF
--- a/build-tasks/back-compat/recommended_ruleset.js
+++ b/build-tasks/back-compat/recommended_ruleset.js
@@ -48,7 +48,7 @@ module.exports = {
         'no-backbone-get-set-outside-model': true,
         'no-bitwise': true,
         'no-conditional-assignment': true,
-        'no-console': [true, 'debug', 'info', 'error', 'log', 'time', 'timeEnd', 'trace'],
+        'no-console': [true, 'debug', 'dir', 'info', 'error', 'log', 'time', 'timeEnd', 'trace'],
         'no-constant-condition': true,
         'no-control-regex': true,
         'no-debugger': true,


### PR DESCRIPTION
#### PR checklist

-   [ ] Addresses an existing issue
-   [x] New feature, bugfix, or enhancement
    -   [ ] Includes tests
-   [ ] Documentation update

#### Overview of change:

We noticed this was missing, allowing workarounds. I know this repo is in hiatus now, but even if you do not merge, it could be useful for people stumbling over this wondering why this does not trigger. We are actually going to override the rule by removing the list of methods, disallowing all `console` methods (and that would be my preferred option for the recommended ruleset, even).

I can add tests and docs as needed, if you happen to want to merge this :)